### PR TITLE
Report errors via 'error' event.

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ The following events can be emitted from the `WebsocketClient`:
 * `open`
 * `message`
 * `close`
+* `error`
 
 ### Orderbook
 `Orderbook` is a data structure that can be used to store a local copy of the orderbook.

--- a/lib/clients/websocket.js
+++ b/lib/clients/websocket.js
@@ -28,6 +28,7 @@ _.assign(WebsocketClient.prototype, new function() {
     self.socket.on('message', self.onMessage.bind(self));
     self.socket.on('open', self.onOpen.bind(self));
     self.socket.on('close', self.onClose.bind(self));
+    self.socket.on('error', self.onError.bind(self));
   };
 
   prototype.disconnect = function() {
@@ -66,6 +67,11 @@ _.assign(WebsocketClient.prototype, new function() {
   prototype.onMessage = function(data) {
     var self = this;
     self.emit('message', JSON.parse(data));
+  };
+
+  prototype.onError = function(err) {
+    var self = this;
+    self.emit('error', err);
   };
 });
 


### PR DESCRIPTION
Currently, network errors emitted by the underlying Websockets library are thrown as exceptions instead of emitted as events, because no handler is bound to the 'error' event. Also, because of the execution context at the point where the exception is being thrown, it is effectively uncatchable by the library consumer.

This pull request solves the problem by adding an 'error' event which handles such errors, allowing the library consumer to respond to error conditions appropriately.
