### PR TITLE
Prevent Pinger Exceptions

### DIFF
--- a/lib/clients/websocket.js
+++ b/lib/clients/websocket.js
@@ -20,6 +20,7 @@ _.assign(WebsocketClient.prototype, new function() {
     var self = this;
 
     if (self.socket) {
+      clearInterval(self.pinger);
       self.socket.close();
     }
 
@@ -32,12 +33,14 @@ _.assign(WebsocketClient.prototype, new function() {
 
   prototype.disconnect = function() {
     var self = this;
+    clearInterval(self.pinger);
 
     if (!self.socket) {
       throw "Could not disconnect (not connected)"
     }
 
     self.socket.close();
+    self.socket = null;
   };
 
   prototype.onOpen = function() {
@@ -51,7 +54,9 @@ _.assign(WebsocketClient.prototype, new function() {
 
     // Set a 30 second ping to keep connection alive
     self.pinger = setInterval(function(){
-      self.socket.ping("keepalive");
+      if (self.socket) {
+        self.socket.ping("keepalive");
+      }
     }, 30000);
 
   };


### PR DESCRIPTION
Under certain error conditions (if the connection is disconnected by the caller during adverse network conditions) the "pinger" setInterval will continue to run, triggering a fatal unhandled exception.

This patch makes gdax-node a little smarter about disabling pinger during any websocket disconnect scenario.
