### PR TITLE
optionally specify productId in authenticated client constructor, passing to public client

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ account's settings](https://gdax.com/settings).
 ```javascript
 var Gdax = require('gdax');
 var authedClient = new Gdax.AuthenticatedClient(
-  key, b64secret, passphrase, productID);
+  key, b64secret, passphrase, apiURL, productID);
 ```
 
 Like the `PublicClient`, all API methods are callback based. The callback

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ account's settings](https://gdax.com/settings).
 ```javascript
 var Gdax = require('gdax');
 var authedClient = new Gdax.AuthenticatedClient(
-  key, b64secret, passphrase);
+  key, b64secret, passphrase, productID);
 ```
 
 Like the `PublicClient`, all API methods are callback based. The callback

--- a/lib/clients/authenticated.js
+++ b/lib/clients/authenticated.js
@@ -13,10 +13,10 @@ var request = require('request');
 var PublicClient = require('./public.js');
 
 
-var AuthenticatedClient = function(key, b64secret, passphrase, apiURI) {
+var AuthenticatedClient = function(key, b64secret, passphrase, apiURI, productId) {
   var self = this;
 
-  PublicClient.call(self, '', apiURI);
+  PublicClient.call(self, productId || '', apiURI);
   self.key = key;
   self.b64secret = b64secret;
   self.passphrase = passphrase;


### PR DESCRIPTION
Edit: as mentioned by @MarcSallent, this solves the issue of not being able to specify a `productId` for methods of `PublicClient` that is inherited by `AuthenticatedClient`