### PR TITLE
fix: Sign websocket 'subscribe' only if auth is given

### DIFF
--- a/lib/clients/websocket.js
+++ b/lib/clients/websocket.js
@@ -54,16 +54,21 @@ _.assign(WebsocketClient.prototype, new function() {
   prototype.onOpen = function() {
     var self = this;
     self.emit('open');
-    var sig = signRequest(self.auth, 'GET', '/users/self');
 
     var subscribeMessage = {
       type: 'subscribe',
-      product_id: self.productID,
-      signature: sig.signature,
-      key: sig.key,
-      passphrase: sig.passphrase,
-      timestamp: sig.timestamp
+      product_id: self.productID
     };
+
+    // Add Signature
+    if (self.auth.secret) {
+      var sig = signRequest(self.auth, 'GET', '/users/self');
+      subscribeMessage.signature = sig.signature
+      subscribeMessage.key = sig.key
+      subscribeMessage.passphrase = sig.passphrase
+      subscribeMessage.timestamp = sig.timestamp
+    }
+
     self.socket.send(JSON.stringify(subscribeMessage));
 
     // Set a 30 second ping to keep connection alive


### PR DESCRIPTION
The current websocket API does not require requests to be signed.

Since `self.auth` is always defined via a default object, I tested whether to sign the request by checking `self.auth.secret` with the assumption that `self.auth.key` and `self.auth.passphrase` could not be undefined if `self.auth.secret` is defined.

fixes #17