### PR TITLE
add engines config

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,5 +58,9 @@
   },
   "scripts": {
     "test": "mocha --ui qunit --bail --reporter list tests/*.js"
+  },
+  "engineStrict" : true,
+  "engines": {
+    "node" : ">=4.0.0"
   }
 }


### PR DESCRIPTION
What Node versions does this npm module support?

I might be wrong, but I'm guessing >= 4. The reason is [Node 0.10, 0.11 and 0.12 have reached end-of-life.](https://github.com/nodejs/LTS#lts-schedule)

