### PR TITLE
lib/orderbook_sync: emit 'message' event

### DIFF
--- a/lib/orderbook_sync.js
+++ b/lib/orderbook_sync.js
@@ -31,6 +31,7 @@ _.assign(OrderbookSync.prototype, new function() {
   prototype.onMessage = function(data) {
     var self = this;
     data = JSON.parse(data);
+    self.emit('message', data);
 
     if (self._sequence ===  -1) {
       // Orderbook snapshot not loaded yet

--- a/tests/orderbook_sync_test.js
+++ b/tests/orderbook_sync_test.js
@@ -1,0 +1,38 @@
+var assert = require('assert');
+var nock = require('nock');
+
+var Gdax = require('../index.js');
+
+var testserver = require('./lib/ws_testserver');
+var port = 56632;
+
+var EXCHANGE_API_URL = 'https://api.gdax.com';
+
+suite('OrderbookSync');
+
+describe('OrderbookSync', function() {
+  test('emits a message event', function(done) {
+    nock(EXCHANGE_API_URL)
+      .get('/products/BTC-USD/book?level=3')
+      .times(2)
+      .reply(200, {
+        asks: [],
+        bids: []
+      });
+
+    var server = testserver(++port, function() {
+      var orderbookSync = new Gdax.OrderbookSync('BTC-USD', EXCHANGE_API_URL, 'ws://localhost:' + port);
+      orderbookSync.on('message', function(data) {
+        assert.deepEqual(data, {
+          test: true,
+        });
+        server.close();
+        done();
+      })
+    });
+
+    server.on('connection', function(socket) {
+      socket.send(JSON.stringify({test: true}));
+    });
+  });
+});


### PR DESCRIPTION
`Gdax.OrderbookSync` inherits from `Gdax.WebsocketClient`. It should therefore emit the same messages on the same events.

The `open`, `close`, and `error` events had not been overriden, but `message` has. This restores it.