### PR TITLE
OrderbookSync: Multiple books

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Change Log
+
+## Unreleased
+
+### Changed
+
+- Modify `lib/orderbook_sync` to be initialized with an array of product IDs instead of one product ID, and have it keep track of multiple books for these products in `orderbookSync.books`. `orderbookSync.book` is removed.

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ publicClient.getTime(callback);
 The [private exchange API
 endpoints](https://docs.gdax.com/#private) require you to
 authenticate with an API key. You can create a new API key [in your exchange
-account's settings](https://gdax.com/settings). You can also specify the 
+account's settings](https://gdax.com/settings). You can also specify the
 API uri.
 
 ```javascript
@@ -342,8 +342,8 @@ The orderbook has the following methods:
 
 ```javascript
 var Gdax = require('gdax');
-var orderbookSync = new Gdax.OrderbookSync();
-console.log(orderbookSync.book.state());
+var orderbookSync = new Gdax.OrderbookSync(['BTC-USD', 'ETH-USD']);
+console.log(orderbookSync.books['ETH-USD'].state());
 ```
 
 ## Testing

--- a/lib/clients/websocket.js
+++ b/lib/clients/websocket.js
@@ -1,5 +1,6 @@
 var EventEmitter = require('events').EventEmitter;
 var Websocket = require('ws');
+var Utils = require('../utilities.js');
 var util = require('util');
 var _  = {assign: require('lodash.assign')};
 var signRequest = require('../../lib/request_signer').signRequest;
@@ -12,7 +13,7 @@ var signRequest = require('../../lib/request_signer').signRequest;
  */
 var WebsocketClient = function(productIDs, websocketURI, auth) {
   var self = this;
-  self.productIDs = self._determineProductIDs(productIDs);
+  self.productIDs = Utils.determineProductIDs(productIDs);
   self.websocketURI = websocketURI || 'wss://ws-feed.gdax.com';
   if (auth && !(auth.secret && auth.key && auth.passphrase)) {
     throw new Error('Invalid or incomplete authentication credentials. You should either provide all of the secret, key and passphrase fields, or leave auth null');
@@ -105,20 +106,6 @@ _.assign(WebsocketClient.prototype, new function() {
 
     self.emit('error', err);
   };
-
-  prototype._determineProductIDs = function(productIDs) {
-    if (!productIDs || !productIDs.length) {
-      return ['BTC-USD'];
-    }
-
-    if (Array.isArray(productIDs)) {
-      return productIDs;
-    }
-
-    // If we got this far, it means it's a string.
-    // Return an array for backwards compatibility.
-    return [productIDs];
-  }
-
 });
+
 module.exports = exports = WebsocketClient;

--- a/lib/orderbook_sync.js
+++ b/lib/orderbook_sync.js
@@ -1,6 +1,7 @@
 var WebsocketClient = require('./clients/websocket.js');
 var PublicClient = require('./clients/public.js');
 var Orderbook = require('./orderbook.js');
+var Utils = require('./utilities.js');
 var util = require('util');
 var _ = {
   forEach: require('lodash.foreach'),
@@ -8,19 +9,27 @@ var _ = {
 };
 
 // Orderbook syncing
-var OrderbookSync = function(productID, apiURI, websocketURI, authenticatedClient) {
+var OrderbookSync = function(productIDs, apiURI, websocketURI, authenticatedClient) {
   var self = this;
 
-  self.productID = productID || 'BTC-USD';
+  self.productIDs = Utils.determineProductIDs(productIDs);
   self.apiURI = apiURI || 'https://api.gdax.com';
   self.websocketURI = websocketURI || 'wss://ws-feed.gdax.com';
   self.authenticatedClient = authenticatedClient;
 
-  self._queue = [];
-  self._sequence = -1;
+  self._queues = {}; // []
+  self._sequences = {}; // -1
+  self._public_clients = {};
+  self.books = {}
 
-  WebsocketClient.call(self, self.productID, self.websocketURI);
-  self.loadOrderbook();
+  _.forEach(self.productIDs, function(productID) {
+    self._queues[productID] = [];
+    self._sequences[productID] = -1;
+    self.books[productID] = new Orderbook();
+    self.loadOrderbook(productID);
+  });
+
+  WebsocketClient.call(self, self.productIDs, self.websocketURI);
 };
 
 util.inherits(OrderbookSync, WebsocketClient);
@@ -33,29 +42,29 @@ _.assign(OrderbookSync.prototype, new function() {
     data = JSON.parse(data);
     self.emit('message', data);
 
-    if (self._sequence ===  -1) {
+    var product_id = data.product_id;
+
+    if (self._sequences[product_id] ===  -1) {
       // Orderbook snapshot not loaded yet
-      self._queue.push(data);
+      self._queues[product_id].push(data);
     } else {
       self.processMessage(data);
     }
   };
 
-  prototype.loadOrderbook = function() {
+  prototype.loadOrderbook = function(productID) {
     var self = this;
     var bookLevel = 3;
     var args = { 'level': bookLevel };
 
-    self.book = new Orderbook();
-
     if (self.authenticatedClient) {
-      self.authenticatedClient.getProductOrderBook(args, self.productID, cb);
+      self.authenticatedClient.getProductOrderBook(args, productID, cb);
     }
     else {
-      if (!self.publicClient) {
-        self.publicClient = new PublicClient(self.productID, self.apiURI);
+      if (!self._public_clients[productID]) {
+        self._public_clients[productID] = new PublicClient(productID, self.apiURI);
       }
-      self.publicClient.getProductOrderBook(args, cb);
+      self._public_clients[productID].getProductOrderBook(args, cb);
     }
 
     function cb(err, response, body) {
@@ -67,57 +76,62 @@ _.assign(OrderbookSync.prototype, new function() {
         throw 'Failed to load orderbook: ' + response.statusCode;
       }
 
-      var data = JSON.parse(response.body);
-      self.book.state(data);
+      if (!self.books[productID]) {
+        return;
+      }
 
-      self._sequence = data.sequence;
-      _.forEach(self._queue, self.processMessage.bind(self));
-      self._queue = [];
+      var data = JSON.parse(response.body);
+      self.books[productID].state(data);
+
+      self._sequences[productID] = data.sequence;
+      _.forEach(self._queues[productID], self.processMessage.bind(self));
+      self._queues[productID] = [];
     };
   };
 
   prototype.processMessage = function(data) {
     var self = this;
+    var product_id = data.product_id;
 
-    if (self._sequence == -1) {
+    if (self._sequences[product_id] == -1) {
       // Resync is in process
       return;
     }
-    if (data.sequence <= self._sequence) {
+    if (data.sequence <= self._sequences[product_id]) {
       // Skip this one, since it was already processed
       return;
     }
 
-    if (data.sequence != self._sequence + 1) {
+    if (data.sequence != self._sequences[product_id] + 1) {
       // Dropped a message, start a resync process
-      self._queue = [];
-      self._sequence = -1;
+      self._queues[product_id] = [];
+      self._sequences[product_id] = -1;
 
-      self.loadOrderbook();
+      self.loadOrderbook(product_id);
       return;
     }
 
-    self._sequence = data.sequence;
+    self._sequences[product_id] = data.sequence;
+    var book = self.books[product_id];
 
     switch (data.type) {
       case 'open':
-        self.book.add(data);
+        book.add(data);
         break;
 
       case 'done':
-        self.book.remove(data.order_id);
+        book.remove(data.order_id);
         break;
 
       case 'match':
-        self.book.match(data);
+        book.match(data);
         break;
 
       case 'change':
-        self.book.change(data);
+        book.change(data);
         break;
     }
   };
-
 });
 
 module.exports = exports = OrderbookSync;

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -1,0 +1,17 @@
+function determineProductIDs(productIDs) {
+  if (!productIDs || !productIDs.length) {
+    return ['BTC-USD'];
+  }
+
+  if (Array.isArray(productIDs)) {
+    return productIDs;
+  }
+
+  // If we got this far, it means it's a string.
+  // Return an array for backwards compatibility.
+  return [productIDs];
+}
+
+module.exports = {
+  determineProductIDs,
+};

--- a/tests/authenticated.js
+++ b/tests/authenticated.js
@@ -11,6 +11,8 @@ var EXCHANGE_API_URL = 'https://api.gdax.com';
 
 var authClient = new Gdax.AuthenticatedClient(key, secret, passphrase);
 
+suite('AuthenticatedClient');
+
 test('._getSignature', function() {
   var method = 'PUT';
   var relativeURI = '/orders';
@@ -18,7 +20,7 @@ test('._getSignature', function() {
     method : 'PUT',
     uri : 'https://api.gdax.com/orders'
   }
-  
+
   var sig = authClient._getSignature(method, relativeURI, opts)
 
   assert.equal(sig['CB-ACCESS-KEY'], key);
@@ -34,7 +36,7 @@ test('get account', function(done) {
     "balance": "1.100",
     "holds": "0.100",
     "available": "1.00",
-    "currency": "USD" 
+    "currency": "USD"
   }
 
   nock(EXCHANGE_API_URL)
@@ -56,7 +58,7 @@ test('get accounts', function(done) {
     "balance": "1.100",
     "holds": "0.100",
     "available": "1.00",
-    "currency": "USD" 
+    "currency": "USD"
   }]
 
   nock(EXCHANGE_API_URL)
@@ -190,7 +192,7 @@ test('get product orderbook', function(done) {
     assert(data);
     done();
   });
-}) 
+})
 
 test('cancel all orders', function(done) {
   // nock three requests to delete /orders
@@ -404,7 +406,7 @@ test('close position', function(done) {
 test('deposit', function(done) {
   var transfer = {
     "amount" : 10480,
-    "coinbase_account_id": 'test-id' 
+    "coinbase_account_id": 'test-id'
   }
 
   expectedTransfer = transfer;
@@ -425,7 +427,7 @@ test('deposit', function(done) {
 test('withdraw', function(done) {
   var transfer = {
     "amount" : 10480,
-    "coinbase_account_id": 'test-id' 
+    "coinbase_account_id": 'test-id'
   }
 
   expectedTransfer = transfer;

--- a/tests/orderbook.js
+++ b/tests/orderbook.js
@@ -6,6 +6,8 @@ var checkState = function(state, exp) {
   assert.deepEqual(JSON.parse(JSON.stringify(state)), exp);
 };
 
+suite('Orderbook');
+
 test('add new orders', function() {
   var state = {
     bids: [

--- a/tests/orderbook_sync_test.js
+++ b/tests/orderbook_sync_test.js
@@ -35,4 +35,37 @@ describe('OrderbookSync', function() {
       socket.send(JSON.stringify({test: true}));
     });
   });
+
+  test('builds specified books', function(done) {
+    nock(EXCHANGE_API_URL)
+      .get('/products/BTC-USD/book?level=3')
+      .times(2)
+      .reply(200, {
+        asks: [],
+        bids: []
+      });
+
+    nock(EXCHANGE_API_URL)
+      .get('/products/ETH-USD/book?level=3')
+      .times(2)
+      .reply(200, {
+        asks: [],
+        bids: []
+      });
+
+    var server = testserver(++port, function() {
+      var orderbookSync = new Gdax.OrderbookSync(['BTC-USD', 'ETH-USD'], EXCHANGE_API_URL, 'ws://localhost:' + port);
+      var btc_usd_state = orderbookSync.books['BTC-USD'].state();
+      var eth_usd_state = orderbookSync.books['ETH-USD'].state();
+
+      assert.deepEqual(btc_usd_state, { asks: [], bids: [] });
+      assert.deepEqual(eth_usd_state, { asks: [], bids: [] });
+      assert.equal(orderbookSync.books['ETH-BTC'], undefined);
+    });
+
+    server.on('connection', function(socket) {
+      server.close();
+      done();
+    });
+  });
 });

--- a/tests/public_client.js
+++ b/tests/public_client.js
@@ -6,6 +6,8 @@ var publicClient = new Gdax.PublicClient();
 
 var EXCHANGE_API_URL = 'https://api.gdax.com';
 
+suite('PublicClient');
+
 test('get product trades', function(done) {
   var expectedResponse = [{
     "time": "2014-11-07T22:19:28.578544Z",
@@ -35,7 +37,7 @@ test('get product trades', function(done) {
 });
 
 test('public client should return values', function(done) {
-  
+
   nock(EXCHANGE_API_URL)
   .get('/products/BTC-USD/ticker')
   .reply(200, {
@@ -50,8 +52,8 @@ test('public client should return values', function(done) {
     assert.equal(data.trade_id, 'test-id');
     assert(data.price, '9.00');
     assert(data.size, '5');
-  
-    nock.cleanAll();    
+
+    nock.cleanAll();
     done();
   });
 });


### PR DESCRIPTION
This is a non-backwards-compatible change since `OrderbookSync` no longer has a `book` property; it now has `books`.

See README.md change:
```
-var orderbookSync = new Gdax.OrderbookSync();
-console.log(orderbookSync.book.state());

+var orderbookSync = new Gdax.OrderbookSync(['BTC-USD', 'ETH-USD']);
+console.log(orderbookSync.books['ETH-USD'].state());
```