### PR TITLE
[DEPS] Upgrade WS to latest stable version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "nock": "3.6.0",
     "num": "0.2.1",
     "request": "2.74.0",
-    "ws": "1.1.1"
+    "ws": "3.0.0"
   },
   "description": "Client for the GDAX API",
   "devDependencies": {


### PR DESCRIPTION
Fix for #64 and #59, caused by lagging WS and bufferUtil mismatch.
100% test coverage for Node LTS v6.11.0