### PR TITLE
Refactored tests/added new tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,5 +58,9 @@
   },
   "scripts": {
     "test": "mocha --ui qunit --bail --reporter list tests/*.js"
+  },
+  "engineStrict" : true,
+  "engines": {
+    "node" : ">=4.0.0"
   }
 }

--- a/tests/orderbook_sync_test.js
+++ b/tests/orderbook_sync_test.js
@@ -65,6 +65,7 @@ describe('OrderbookSync', function() {
 
     server.on('connection', function(socket) {
       server.close();
+      nock.clearAll();
       done();
     });
   });


### PR DESCRIPTION
Hi,

I am trying to fix #63 this bug and I noticed that the tests in tests/public_client.js are very insufficient to begin with and actually do not cover many of the uses cases correctly. To begin with, I added tests that would make sure the error object in the callback to PublicClient.getProductTrades behaves as expected, because as noted above #63 it does not do so currently. 

tests/orderbook_sync_test.js
I noticed that my tests were not behaving correctly because an Error object was being returned in the first test, but a quick console.log(err) in the test showed that my test's getProductTrades is still calling the nock mock which was weird because I did not use nock. 
`․ OrderbookSync builds specified books: 13ms
    PublicClient PublicClient with bad market input should return error on call to getProductTrades: { [Error: Nock: No match for request GET https://api.gdax.com/products/non-existant%20market/trades ] status: 404, statusCode: 404 }`

I figured that 'OrderbokSync builds specified books' suite was not clearing nock and I was correct so I added the line 'nock.clearAll();' (other files have tests that miss this line as well but I will take care of that in other commits)

