### PR TITLE
Delayed initial orderbook sync until first message is received (#62).

### DIFF
--- a/lib/orderbook_sync.js
+++ b/lib/orderbook_sync.js
@@ -21,9 +21,8 @@ class OrderbookSync extends WebsocketClient {
 
     this.productIDs.forEach(productID => {
       this._queues[productID] = [];
-      this._sequences[productID] = -1;
+      this._sequences[productID] = -2;
       this.books[productID] = new Orderbook();
-      this.loadOrderbook(productID);
     });
   }
 
@@ -33,9 +32,15 @@ class OrderbookSync extends WebsocketClient {
 
     const { product_id } = data;
 
-    if (this._sequences[product_id] === -1) {
+    if (this._sequences[product_id] < 0) {
       // Orderbook snapshot not loaded yet
       this._queues[product_id].push(data);
+
+      if (this._sequences[product_id] === -2) {
+         // Start first resync
+         this._sequences[product_id] = -1;
+         this.loadOrderbook(product_id);
+      }
     } else {
       this.processMessage(data);
     }
@@ -71,7 +76,7 @@ class OrderbookSync extends WebsocketClient {
       this.books[productID].state(data);
 
       this._sequences[productID] = data.sequence;
-      this._queues[productID].forEach(this.processMessage);
+      this._queues[productID].forEach(this.processMessage.bind(this));
       this._queues[productID] = [];
     }
 


### PR DESCRIPTION
The orderbook sync issue happens when the initial loadOrderbook finishes before the websocket client has subscribed to any products, which will cause some initial updates to be missed. This can also cause several unnecessary resyncs. Waiting until after the first message for that product is received resolved the issue (#62, #80) in my testing. A setTimeout for several seconds on the initial loadOrderbook call works most of the time as well, but it is not guaranteed.