### PR TITLE
fix(asks): They were in wrong order.

### DIFF
--- a/lib/orderbook.js
+++ b/lib/orderbook.js
@@ -36,7 +36,7 @@ class Orderbook {
       book = { asks: [], bids: [] };
 
       this._bids.reach(bid => book.bids.push(...bid.orders));
-      this._asks.reach(ask => book.asks.push(...ask.orders));
+      this._asks.each(ask => book.asks.push(...ask.orders));
 
       return book;
     }


### PR DESCRIPTION
Asks in 0.4.2 were using `each` but in this version they are using `reach`.  Thus causing them to be backwards.