### PR TITLE
On opened before heartbeat check connection is open

### DIFF
--- a/lib/clients/websocket.js
+++ b/lib/clients/websocket.js
@@ -69,21 +69,26 @@ class WebsocketClient extends EventEmitter {
 
     this.socket.send(JSON.stringify(subscribeMessage));
 
-    if (this.heartbeat) {
-      // send heartbeat
-      var heartbeatMessage = {
-        type: 'heartbeat',
-        on: true,
-      };
-      this.socket.send(JSON.stringify(heartbeatMessage));
-    } else {
-      // Set a 30 second ping to keep connection alive
-      this.pinger = setInterval(() => {
-        if (this.socket) {
-          this.socket.ping('keepalive');
-        }
-      }, 30000);
+    if (this.socket.readyState === this.socket.OPEN) {
+
+      if (this.heartbeat ) {
+        // send heartbeat
+        var heartbeatMessage = {
+          type: 'heartbeat',
+          on: true,
+        };
+        this.socket.send(JSON.stringify(heartbeatMessage));
+      } else {
+        // Set a 30 second ping to keep connection alive
+        this.pinger = setInterval(() => {
+          if (this.socket) {
+            this.socket.ping('keepalive');
+          }
+        }, 30000);
+      }
+
     }
+
   }
 
   onClose() {


### PR DESCRIPTION
After connection Hearbeat is send:

> /node_modules/ws/lib/WebSocket.js:160
throw new Error('not opened');
^
Error: not opened
	at WebSocket.ping (/node_modules/ws/lib/WebSocket.js:160:11)
	at Timeout._onTimeout (/node_modules/gdax/lib/clients/websocket.js:77:19)
	at ontimeout (timers.js:469:11)
	at tryOnTimeout (timers.js:304:5)
	at Timer.listOnTimeout (timers.js:264:5)


With this implementation it's impossible to catch this error, exit process ....

To avoid check WS is connected before send hearbeat