### PR TITLE
Added proxy support for Websocket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,4 +4,4 @@
 
 ### Changed
 
-- Modify `lib/orderbook_sync` to be initialized with an array of product IDs instead of one product ID, and have it keep track of multiple books for these products in `orderbookSync.books`. `orderbookSync.book` is removed.
+- Let `Websocket` use proxy defined via `https_proxy` or `http_proxy` environment variables

--- a/lib/clients/websocket.js
+++ b/lib/clients/websocket.js
@@ -1,5 +1,7 @@
 const { EventEmitter } = require('events');
 const Websocket = require('ws');
+const url = require('url');
+const HttpsProxyAgent = require('https-proxy-agent');
 const Utils = require('../utilities.js');
 const { signRequest } = require('../../lib/request_signer');
 
@@ -36,7 +38,18 @@ class WebsocketClient extends EventEmitter {
       this.socket.close();
     }
 
-    this.socket = new Websocket(this.websocketURI);
+    let proxyUrl = null;
+    let socketOpts = {};
+    if (process.env.https_proxy) {
+        proxyUrl = process.env.https_proxy;
+    } else if (process.env.http_proxy) {
+      proxyUrl = process.env.http_proxy;
+    }
+    if (proxyUrl) {
+        socketOpts.agent = new HttpsProxyAgent(url.parse(proxyUrl));
+    }
+
+    this.socket = new Websocket(this.websocketURI, socketOpts);
 
     this.socket.on('message', this.onMessage.bind(this));
     this.socket.on('open', this.onOpen.bind(this));

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "bintrees": "1.0.1",
     "num": "0.3.0",
     "request": "2.81.0",
-    "ws": "3.0.0"
+    "ws": "3.0.0",
+    "https-proxy-agent": "^2.1.0"
   },
   "description": "Client for the GDAX API",
   "devDependencies": {


### PR DESCRIPTION
Simplistic support for `Websocket` connections via proxy server. Server address & port are taken from `https_proxy` or `http_proxy` environment variables. Not thoroughly tested yet it works via my corporate proxy. Inactive and transparent if no environment is set.