### PR TITLE
Configured array formatting in request extra parameters to 'repeat'

### DIFF
--- a/lib/clients/public.js
+++ b/lib/clients/public.js
@@ -73,6 +73,7 @@ class PublicClient {
     Object.assign(opts, {
       method: method.toUpperCase(),
       uri: this.makeAbsoluteURI(this.makeRelativeURI(uriParts)),
+      qsStringifyOptions: { arrayFormat: 'repeat' },
     });
     this.addHeaders(opts);
     const p = new Promise((resolve, reject) => {


### PR DESCRIPTION
This way it is possible to make calls like:

  AuthenticatedClient.getOrders({ status: ['open', 'done'] });

Previously it caused signature errors as arrays were formatted
with indices.