### PR TITLE
Added productID to authClient/Updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ publicClient
 const publicClient = new Gdax.PublicClient(productID, endpoint);
 ```
 
-- `productID` *optional* - defaults to 'BTC-USD' if not specified.
+- `productID` *optional* - defaults to 'BTC-USD' if not specified. Other values accepted are 'ETH-USD' and 'LTC-USD'
 - `endpoint` *optional* - defaults to 'https://api.gdax.com' if not specified.
 
 #### Public API Methods
@@ -222,10 +222,11 @@ const key = 'your_api_key';
 const b64secret = 'your_b64_secret';
 const passphrase = 'your_passphrase';
 
+const productID = 'BTC-USD';
 const apiURI = 'https://api.gdax.com';
 const sandboxURI = 'https://api-public.sandbox.gdax.com';
 
-const authedClient = new Gdax.AuthenticatedClient(key, b64secret, passphrase, apiURI);
+const authedClient = new Gdax.AuthenticatedClient(key, b64secret, passphrase, productID, apiURI);
 ```
 
 Like `PublicClient`, all API methods can be used with either callbacks or will

--- a/index.d.ts
+++ b/index.d.ts
@@ -132,7 +132,7 @@ declare module "gdax" {
     };
 
     export class PublicClient {
-        constructor(productId?: string);
+        constructor(productId?: string, apiURI?: string);
 
         getProducts(callback: callback<any>);
         getProducts(): Promise<any>;
@@ -163,7 +163,7 @@ declare module "gdax" {
     }
 
     export class AuthenticatedClient {
-        constructor(key: string, b64secret: string, passphrase: string, apiURI: string);
+        constructor(key: string, b64secret: string, passphrase: string, productID?: string, apiURI?: string);
 
         getCoinbaseAccounts(callback: callback<CoinbaseAccount[]>)
         getCoinbaseAccounts(): Promise<CoinbaseAccount[]>;

--- a/lib/clients/authenticated.js
+++ b/lib/clients/authenticated.js
@@ -3,8 +3,8 @@ const { signRequest } = require('../../lib/request_signer');
 const PublicClient = require('./public.js');
 
 class AuthenticatedClient extends PublicClient {
-  constructor(key, b64secret, passphrase, apiURI) {
-    super('', apiURI);
+  constructor(key, b64secret, passphrase, productID, apiURI) {
+    super(productID, apiURI);
     this.key = key;
     this.b64secret = b64secret;
     this.passphrase = passphrase;


### PR DESCRIPTION
Added the fix so that when constructing the authClient class, you can include the specified productID. Also updated the readme so that the 3 available productID's are listed under the publicClient section.