### PR TITLE
remove use of deprecated /transfers route

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,28 +387,32 @@ authedClient.closePosition(params, callback);
 ```js
 // Deposit to your Exchange USD account from your Coinbase USD account.
 const depositParamsUSD = {
-  'amount': '100.00', // USD,
+  'amount': '100.00',
+  'currency': 'USD',
   'coinbase_account_id': '60680c98bfe96c2601f27e9c', // USD Coinbase Account ID
 };
 authedClient.deposit(depositParamsUSD, callback);
 
 // Withdraw from your Exchange USD account to your Coinbase USD account.
 const withdrawParamsUSD = {
-  'amount': '100.00', // USD,
+  'amount': '100.00',
+  'currency': 'USD',
   'coinbase_account_id': '60680c98bfe96c2601f27e9c', // USD Coinbase Account ID
 };
 authedClient.withdraw(withdrawParamsUSD, callback);
 
 // Deposit to your Exchange BTC account from your Coinbase BTC account.
 const depositParamsBTC = {
-  'amount': '2.0', // BTC,
+  'amount': '2.0',
+  'currency': 'BTC',
   'coinbase_account_id': '536a541fa9393bb3c7000023', // BTC Coinbase Account ID
 };
 authedClient.deposit(depositParamsBTC, callback);
 
 // Withdraw from your Exchange BTC account to your Coinbase BTC account.
 const withdrawParamsBTC = {
-  'amount': '2.0', // BTC,
+  'amount': '2.0',
+  'currency': 'BTC',
   'coinbase_account_id': '536a541fa9393bb3c7000023', // BTC Coinbase Account ID
 };
 authedClient.withdraw(withdrawParamsBTC, callback);
@@ -419,7 +423,7 @@ const withdrawAddressParams = {
   'currency': 'BTC',
   'crypto_address': '15USXR6S4DhSWVHUxXRCuTkD1SA6qAdy'
 }
-authedClient.withdraw(withdrawAddressParams, callback);
+authedClient.withdrawCrypto(withdrawAddressParams, callback);
 ```
 
 * [`getTrailingVolume`](https://docs.gdax.com/#user-account)

--- a/lib/clients/authenticated.js
+++ b/lib/clients/authenticated.js
@@ -239,23 +239,22 @@ class AuthenticatedClient extends PublicClient {
   }
 
   deposit(params, callback) {
-    params.type = 'deposit';
-    return this._transferFunds(params, callback);
+    this._requireParams(params, ['amount', 'currency', 'coinbase_account_id']);
+    return this.post(['deposits/coinbase-account'], { body: params }, callback);
   }
 
   withdraw(params, callback) {
-    params.type = 'withdraw';
-    return this._transferFunds(params, callback);
+    this._requireParams(params, ['amount', 'currency', 'coinbase_account_id']);
+    return this.post(
+      ['withdrawals/coinbase-account'],
+      { body: params },
+      callback
+    );
   }
 
   withdrawCrypto(body, callback) {
-    this._requireParams(body, ['amount', 'currency', 'crypto_address'])
-    return this.post(['withdrawals/crypto'], { body }, callback)
-  }
-
-  _transferFunds(params, callback) {
-    this._requireParams(params, ['type', 'amount', 'coinbase_account_id']);
-    return this.post(['transfers'], { body: params }, callback);
+    this._requireParams(body, ['amount', 'currency', 'crypto_address']);
+    return this.post(['withdrawals/crypto'], { body }, callback);
   }
 
   _requireParams(params, required) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gdax",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "author": "Coinbase",
   "bugs": "https://github.com/coinbase/gdax-node/issues",
   "contributors": [

--- a/tests/authenticated.spec.js
+++ b/tests/authenticated.spec.js
@@ -672,14 +672,14 @@ suite('AuthenticatedClient', () => {
   test('.deposit()', done => {
     const transfer = {
       amount: 10480,
+      currency: 'USD',
       coinbase_account_id: 'test-id',
     };
 
     const expectedTransfer = transfer;
-    expectedTransfer.type = 'deposit';
 
     nock(EXCHANGE_API_URL)
-      .post('/transfers', expectedTransfer)
+      .post('/deposits/coinbase-account', expectedTransfer)
       .times(2)
       .reply(200, {});
 
@@ -702,14 +702,14 @@ suite('AuthenticatedClient', () => {
   test('.withdraw()', done => {
     const transfer = {
       amount: 10480,
+      currency: 'USD',
       coinbase_account_id: 'test-id',
     };
 
     const expectedTransfer = transfer;
-    expectedTransfer.type = 'withdraw';
 
     nock(EXCHANGE_API_URL)
-      .post('/transfers', expectedTransfer)
+      .post('/withdrawals/coinbase-account', expectedTransfer)
       .times(2)
       .reply(200, {});
 


### PR DESCRIPTION
The use of the `/transfers` route has been deprecated for some time. Instead we should be using the routes specifically for coinbase [deposits](https://docs.gdax.com/#coinbase) and [withdrawals](https://docs.gdax.com/#coinbase54).

Note: This change is not backwards compatible as the `currency` must now be defined as well.