### PR TITLE
Include response in promise rejections

### DIFF
--- a/lib/clients/authenticated.js
+++ b/lib/clients/authenticated.js
@@ -147,7 +147,9 @@ class AuthenticatedClient extends PublicClient {
       return new Promise((resolve, reject) => {
         this.delete(['orders'], opts, (err, response, data) => {
           if (err || data === null) {
-            reject(err || 'Could not delete all orders');
+            err = err || new Error('Could not delete all orders');
+            err.response = response;
+            reject(err);
           } else {
             resolve([response, data]);
           }

--- a/lib/clients/public.js
+++ b/lib/clients/public.js
@@ -54,10 +54,13 @@ class PublicClient {
         return;
       }
       if (err) {
+        err.response = response;
         reject(err);
       }
       if (data === null) {
-        reject(new Error('Response could not be parsed as JSON'));
+        err = new Error('Response could not be parsed as JSON');
+        err.response = response;
+        reject(err);
       } else {
         resolve(data);
       }


### PR DESCRIPTION
The response is currently only included in callbacks and dropped in Promise requests.
This PR attaches the response to the error object in rejected promises.