### PR TITLE
Refactor auth object to { key, secret, passphrase }

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,13 +219,13 @@ the API URI (defaults to `https://api.gdax.com`).
 
 ```js
 const key = 'your_api_key';
-const b64secret = 'your_b64_secret';
+const secret = 'your_b64_secret';
 const passphrase = 'your_passphrase';
 
 const apiURI = 'https://api.gdax.com';
 const sandboxURI = 'https://api-public.sandbox.gdax.com';
 
-const authedClient = new Gdax.AuthenticatedClient(key, b64secret, passphrase, apiURI);
+const authedClient = new Gdax.AuthenticatedClient(key, secret, passphrase, apiURI);
 ```
 
 Like `PublicClient`, all API methods can be used with either callbacks or will

--- a/index.d.ts
+++ b/index.d.ts
@@ -164,7 +164,7 @@ declare module 'gdax' {
     }
 
     export class AuthenticatedClient {
-        constructor(key: string, b64secret: string, passphrase: string, apiURI: string);
+        constructor(key: string, secret: string, passphrase: string, apiURI: string);
 
         getCoinbaseAccounts(callback: callback<CoinbaseAccount[]>)
         getCoinbaseAccounts(): Promise<CoinbaseAccount[]>;

--- a/lib/clients/authenticated.js
+++ b/lib/clients/authenticated.js
@@ -3,10 +3,10 @@ const { signRequest } = require('../../lib/request_signer');
 const PublicClient = require('./public.js');
 
 class AuthenticatedClient extends PublicClient {
-  constructor(key, b64secret, passphrase, apiURI) {
+  constructor(key, secret, passphrase, apiURI) {
     super('', apiURI);
     this.key = key;
-    this.b64secret = b64secret;
+    this.secret = secret;
     this.passphrase = passphrase;
   }
 
@@ -29,12 +29,7 @@ class AuthenticatedClient extends PublicClient {
   }
 
   _getSignature(method, relativeURI, opts) {
-    const auth = {
-      key: this.key,
-      secret: this.b64secret,
-      passphrase: this.passphrase,
-    };
-    const sig = signRequest(auth, method, relativeURI, opts);
+    const sig = signRequest(this, method, relativeURI, opts);
 
     if (opts.body) {
       opts.body = JSON.stringify(opts.body);

--- a/lib/orderbook_sync.js
+++ b/lib/orderbook_sync.js
@@ -11,16 +11,7 @@ class OrderbookSync extends WebsocketClient {
     authenticatedClient = null,
     { heartbeat = false } = {}
   ) {
-    let auth = null;
-    if (authenticatedClient) {
-      auth = {
-        key: authenticatedClient.key,
-        secret: authenticatedClient.b64secret,
-        passphrase: authenticatedClient.passphrase,
-      };
-    }
-
-    super(productIDs, websocketURI, auth, { heartbeat });
+    super(productIDs, websocketURI, authenticatedClient, { heartbeat });
     this.apiURI = apiURI;
     this.authenticatedClient = authenticatedClient;
 


### PR DESCRIPTION
This more consistent usage allows an `AuthenticatedClient` instance to be used
in place of an `auth` object thereby simplifying codebase and general usage patterns.

`AuthenticatedClient` used to have a `b64secret` property, but all auth object credentials expected a `secret` property. By making the two consistent, we gain better consistency, and the codebase can be simplified a bit.

**Other considerations**
This will likely need to be rebased after #150 is merged.