### PR TITLE
Simplify OrderbookSync constructor signature

### DIFF
--- a/lib/clients/websocket.js
+++ b/lib/clients/websocket.js
@@ -19,13 +19,8 @@ class WebsocketClient extends EventEmitter {
     super();
     this.productIDs = Utils.determineProductIDs(productIDs);
     this.websocketURI = websocketURI;
-    if (auth && !(auth.secret && auth.key && auth.passphrase)) {
-      throw new Error(
-        'Invalid or incomplete authentication credentials. You should either provide all of the secret, key and passphrase fields, or leave auth null'
-      );
-    }
     this.channels = channels;
-    this.auth = auth || {};
+    this.auth = Utils.checkAuth(auth);
     this.heartbeat = heartbeat;
     this.connect();
   }

--- a/lib/orderbook_sync.js
+++ b/lib/orderbook_sync.js
@@ -1,6 +1,8 @@
 const WebsocketClient = require('./clients/websocket.js');
+const AuthenticatedClient = require('./clients/authenticated.js');
 const PublicClient = require('./clients/public.js');
 const Orderbook = require('./orderbook.js');
+const Utils = require('./utilities.js');
 
 // Orderbook syncing
 class OrderbookSync extends WebsocketClient {
@@ -8,17 +10,26 @@ class OrderbookSync extends WebsocketClient {
     productIDs,
     apiURI = 'https://api.gdax.com',
     websocketURI = 'wss://ws-feed.gdax.com',
-    authenticatedClient = null,
+    auth = null,
     { heartbeat = false } = {}
   ) {
-    super(productIDs, websocketURI, authenticatedClient, { heartbeat });
+    super(productIDs, websocketURI, auth, { heartbeat });
     this.apiURI = apiURI;
-    this.authenticatedClient = authenticatedClient;
+    this.auth = Utils.checkAuth(auth);
 
     this._queues = {}; // []
     this._sequences = {}; // -1
     this._public_clients = {};
     this.books = {};
+
+    if (this.auth.secret) {
+      this._authenticatedClient = new AuthenticatedClient(
+        this.auth.key,
+        this.auth.secret,
+        this.auth.passphrase,
+        this.apiURI
+      );
+    }
 
     this.productIDs.forEach(productID => {
       this._queues[productID] = [];
@@ -55,8 +66,8 @@ class OrderbookSync extends WebsocketClient {
     const bookLevel = 3;
     const args = { level: bookLevel };
 
-    if (this.authenticatedClient) {
-      this.authenticatedClient
+    if (this._authenticatedClient) {
+      this._authenticatedClient
         .getProductOrderBook(args, productID)
         .then(onData.bind(this))
         .catch(onError.bind(this));

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -12,6 +12,16 @@ function determineProductIDs(productIDs) {
   return [productIDs];
 }
 
+function checkAuth(auth) {
+  if (auth && !(auth.secret && auth.key && auth.passphrase)) {
+    throw new Error(
+      'Invalid or incomplete authentication credentials. You should either provide all of the secret, key and passphrase fields, or leave auth null'
+    );
+  }
+  return auth || {};
+}
+
 module.exports = {
   determineProductIDs,
+  checkAuth,
 };

--- a/tests/orderbook_sync.spec.js
+++ b/tests/orderbook_sync.spec.js
@@ -31,18 +31,13 @@ suite('OrderbookSync', () => {
     });
   });
 
-  test('passes authentication details to websocket (with AuthenticatedClient)', done => {
+  test('passes authentication details to websocket', done => {
     const server = testserver(++port, () => {
-      const authClient = new Gdax.AuthenticatedClient(
-        'suchkey',
-        'suchsecret',
-        'muchpassphrase'
-      );
       new Gdax.OrderbookSync(
         'BTC-USD',
         EXCHANGE_API_URL,
         'ws://localhost:' + port,
-        authClient
+        { key: 'suchkey', secret: 'suchsecret', passphrase: 'muchpassphrase' }
       );
     });
 
@@ -89,7 +84,7 @@ suite('OrderbookSync', () => {
     });
   });
 
-  test('emits a message event (with AuthenticatedClient)', done => {
+  test('emits a message event (with auth)', done => {
     nock(EXCHANGE_API_URL)
       .get('/products/BTC-USD/book?level=3')
       .times(2)
@@ -99,12 +94,11 @@ suite('OrderbookSync', () => {
       });
 
     const server = testserver(++port, () => {
-      const authClient = new Gdax.AuthenticatedClient('key', 'secret', 'pass');
       const orderbookSync = new Gdax.OrderbookSync(
         'BTC-USD',
         EXCHANGE_API_URL,
         'ws://localhost:' + port,
-        authClient
+        { key: 'key', secret: 'secret', passphrase: 'pass' }
       );
       orderbookSync.on('message', data => {
         assert.deepEqual(data, {
@@ -147,18 +141,17 @@ suite('OrderbookSync', () => {
     });
   });
 
-  test('emits an error event on error (with AuthenticatedClient)', done => {
+  test('emits an error event on error (with auth)', done => {
     nock(EXCHANGE_API_URL)
       .get('/products/BTC-USD/book?level=3')
       .replyWithError('whoops');
 
     const server = testserver(++port, () => {
-      const authClient = new Gdax.AuthenticatedClient('key', 'secret', 'pass');
       const orderbookSync = new Gdax.OrderbookSync(
         'BTC-USD',
         EXCHANGE_API_URL,
         'ws://localhost:' + port,
-        authClient
+        { key: 'key', secret: 'secret', passphrase: 'pass' }
       );
 
       orderbookSync.on('message', () =>


### PR DESCRIPTION
This is a direct follow-up to https://github.com/coinbase/gdax-node/pull/151#issuecomment-348232843

- Adds a `checkAuth()`  utility function to ensure an `auth` object contains `key`, `secret`, and `passphrase`
- Simplifies `OrderbookSync` constructor to take auth object instead of a full `AuthenticatedClient` instance

This is still backwards compatible with the old constructor signature, because `AuthenticatedClient` has the same `key`, `secret`, and `passphrase` properties.

/cc @fb55 