### PR TITLE
Normalize PublicClient with AuthenticatedClient 

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,13 +153,13 @@ publicClient.getProducts(callback);
 publicClient.getProductOrderBook('BTC-USD', callback);
 
 // Get the order book at a specific level of detail.
-publicClient.getProductOrderBook('LTC-USD', {'level': 3}, callback);
+publicClient.getProductOrderBook('LTC-USD', { level: 3 }, callback);
 ```
 
 * [`getProductTicker`](https://docs.gdax.com/#get-product-ticker)
 
 ```js
-publicClient.getProductTicker(callback);
+publicClient.getProductTicker('ETH-USD', callback);
 ```
 
 * [`getProductTrades`](https://docs.gdax.com/#get-trades)
@@ -168,7 +168,7 @@ publicClient.getProductTicker(callback);
 publicClient.getProductTrades(callback);
 
 // To make paginated requests, include page parameters
-publicClient.getProductTrades({'after': 1000}, callback);
+publicClient.getProductTrades({ after: 1000 }, callback);
 ```
 
 * [`getProductTradeStream`](https://docs.gdax.com/#get-trades)
@@ -189,7 +189,7 @@ const trades = publicClient.getProductTradeStream(8408000, trade => Date.parse(t
 publicClient.getProductHistoricRates(callback);
 
 // To include extra parameters:
-publicClient.getProductHistoricRates({'granularity': 3000}, callback);
+publicClient.getProductHistoricRates({ granularity: 3000 }, callback);
 ```
 
 * [`getProduct24HrStats`](https://docs.gdax.com/#get-24hr-stats)
@@ -269,7 +269,7 @@ const accountID = '7d0f7d8e-dd34-4d9c-a846-06f431c381ba';
 authedClient.getAccountHistory(accountID, callback);
 
 // For pagination, you can include extra page arguments
-authedClient.getAccountHistory(accountID, {'before': 3000}, callback);
+authedClient.getAccountHistory(accountID, { before: 3000 }, callback);
 ```
 
 * [`getAccountHolds`](https://docs.gdax.com/#get-holds)
@@ -279,7 +279,7 @@ const accountID = '7d0f7d8e-dd34-4d9c-a846-06f431c381ba';
 authedClient.getAccountHolds(accountID, callback);
 
 // For pagination, you can include extra page arguments
-authedClient.getAccountHolds(accountID, {'before': 3000}, callback);
+authedClient.getAccountHolds(accountID, { before: 3000 }, callback);
 ```
 
 * [`buy`, `sell`](https://docs.gdax.com/#place-a-new-order)
@@ -346,7 +346,7 @@ authedClient.cancelAllOrders({product_id: 'BTC-USD'}, callback);
 ```js
 authedClient.getOrders(callback);
 // For pagination, you can include extra page arguments
-authedClient.getOrders({'after': 3000}, callback);
+authedClient.getOrders({ after: 3000 }, callback);
 ```
 
 * [`getOrder`](https://docs.gdax.com/#get-an-order)
@@ -361,7 +361,7 @@ authedClient.getOrder(orderID, callback);
 ```js
 authedClient.getFills(callback);
 // For pagination, you can include extra page arguments
-authedClient.getFills({'before': 3000}, callback);
+authedClient.getFills({ before: 3000 }, callback);
 ```
 
 * [`getFundings`](https://docs.gdax.com/#list-fundings)

--- a/README.md
+++ b/README.md
@@ -177,10 +177,10 @@ Wraps around `getProductTrades`, fetches all trades with IDs `>= tradesFrom` and
 `<= tradesTo`. Handles pagination and rate limits.
 
 ```js
-const trades = publicClient.getProductTradeStream(8408000, 8409000);
+const trades = publicClient.getProductTradeStream('BTC-USD', 8408000, 8409000);
 
 // tradesTo can also be a function
-const trades = publicClient.getProductTradeStream(8408000, trade => Date.parse(trade.time) >= 1463068e6);
+const trades = publicClient.getProductTradeStream('BTC-USD', 8408000, trade => Date.parse(trade.time) >= 1463068e6);
 ```
 
 * [`getProductHistoricRates`](https://docs.gdax.com/#get-historic-rates)

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Some methods accept optional parameters, e.g.
 
 ```js
 publicClient
-  .getProductOrderBook({ level: 3 })
+  .getProductOrderBook('BTC-USD', { level: 3 })
   .then(book => { /* ... */ });
 ```
 
@@ -126,7 +126,7 @@ parameter(s) and the callback as the last parameter:
 
 ```js
 publicClient
-  .getProductOrderBook({ level: 3 }, (error, response, book) => { /* ... */ });
+  .getProductOrderBook('ETH-USD', { level: 3 }, (error, response, book) => { /* ... */ });
 ```
 
 ### The Public API Client
@@ -150,10 +150,10 @@ publicClient.getProducts(callback);
 
 ```js
 // Get the order book at the default level of detail.
-publicClient.getProductOrderBook(callback);
+publicClient.getProductOrderBook('BTC-USD', callback);
 
 // Get the order book at a specific level of detail.
-publicClient.getProductOrderBook({'level': 3}, callback);
+publicClient.getProductOrderBook('LTC-USD', {'level': 3}, callback);
 ```
 
 * [`getProductTicker`](https://docs.gdax.com/#get-product-ticker)

--- a/README.md
+++ b/README.md
@@ -165,10 +165,10 @@ publicClient.getProductTicker('ETH-USD', callback);
 * [`getProductTrades`](https://docs.gdax.com/#get-trades)
 
 ```js
-publicClient.getProductTrades(callback);
+publicClient.getProductTrades('BTC-USD', callback);
 
 // To make paginated requests, include page parameters
-publicClient.getProductTrades({ after: 1000 }, callback);
+publicClient.getProductTrades('BTC-USD', { after: 1000 }, callback);
 ```
 
 * [`getProductTradeStream`](https://docs.gdax.com/#get-trades)

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ publicClient
 ### The Public API Client
 
 ```js
-const publicClient = new Gdax.PublicClient(productID, endpoint);
+const publicClient = new Gdax.PublicClient(endpoint);
 ```
 
 - `productID` *optional* - defaults to 'BTC-USD' if not specified.

--- a/README.md
+++ b/README.md
@@ -186,10 +186,10 @@ const trades = publicClient.getProductTradeStream('BTC-USD', 8408000, trade => D
 * [`getProductHistoricRates`](https://docs.gdax.com/#get-historic-rates)
 
 ```js
-publicClient.getProductHistoricRates(callback);
+publicClient.getProductHistoricRates('BTC-USD', callback);
 
 // To include extra parameters:
-publicClient.getProductHistoricRates({ granularity: 3000 }, callback);
+publicClient.getProductHistoricRates('BTC-USD', { granularity: 3000 }, callback);
 ```
 
 * [`getProduct24HrStats`](https://docs.gdax.com/#get-24hr-stats)

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ publicClient.getProductHistoricRates('BTC-USD', { granularity: 3000 }, callback)
 * [`getProduct24HrStats`](https://docs.gdax.com/#get-24hr-stats)
 
 ```js
-publicClient.getProduct24HrStats(callback);
+publicClient.getProduct24HrStats('BTC-USD', callback);
 ```
 
 * [`getCurrencies`](https://docs.gdax.com/#get-currencies)

--- a/index.d.ts
+++ b/index.d.ts
@@ -141,8 +141,8 @@ declare module 'gdax' {
         getProductOrderBook(productID: string, options: any, callback: callback<any>);
         getProductOrderBook(productID: string, options: any): Promise<any>;
 
-        getProductTicker(callback: callback<ProductTicker>);
-        getProductTicker(): Promise<ProductTicker>;
+        getProductTicker(productID: string, callback: callback<ProductTicker>);
+        getProductTicker(productID: string, ): Promise<ProductTicker>;
 
         getProductTrades(callback: callback<any>);
         getProductTrades(): Promise<any>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -147,8 +147,8 @@ declare module 'gdax' {
         getProductTrades(productID: string, callback: callback<any>);
         getProductTrades(productID: string, ): Promise<any>;
 
-        getProductTradeStream(callback: callback<any>);
-        getProductTradeStream(): Promise<any>;
+        getProductTradeStream(productID: string, tradesFrom: number, tradesTo: any, callback: callback<any>);
+        getProductTradeStream(productID: string, tradesFrom: number, tradesTo: any): Promise<any>;
 
         getProductHistoricRates(args: any, callback: callback<any[][]>);
         getProductHistoricRates(args: any): Promise<any[][]>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -138,8 +138,8 @@ declare module 'gdax' {
         getProducts(callback: callback<ProductInfo[]>);
         getProducts(): Promise<ProductInfo[]>;
 
-        getProductOrderBook(options: any, callback: callback<any>);
-        getProductOrderBook(options: any): Promise<any>;
+        getProductOrderBook(productID: string, options: any, callback: callback<any>);
+        getProductOrderBook(productID: string, options: any): Promise<any>;
 
         getProductTicker(callback: callback<ProductTicker>);
         getProductTicker(): Promise<ProductTicker>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -150,8 +150,8 @@ declare module 'gdax' {
         getProductTradeStream(productID: string, tradesFrom: number, tradesTo: any, callback: callback<any>);
         getProductTradeStream(productID: string, tradesFrom: number, tradesTo: any): Promise<any>;
 
-        getProductHistoricRates(args: any, callback: callback<any[][]>);
-        getProductHistoricRates(args: any): Promise<any[][]>;
+        getProductHistoricRates(productID: string, args: any, callback: callback<any[][]>);
+        getProductHistoricRates(productID: string, args: any): Promise<any[][]>;
 
         getProduct24HrStats(callback: callback<any>);
         getProduct24HrStats(): Promise<any>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -133,7 +133,7 @@ declare module 'gdax' {
     }
 
     export class PublicClient {
-        constructor(productId?: string, apiURI?: string);
+        constructor(apiURI?: string);
 
         getProducts(callback: callback<ProductInfo[]>);
         getProducts(): Promise<ProductInfo[]>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -144,8 +144,8 @@ declare module 'gdax' {
         getProductTicker(productID: string, callback: callback<ProductTicker>);
         getProductTicker(productID: string, ): Promise<ProductTicker>;
 
-        getProductTrades(callback: callback<any>);
-        getProductTrades(): Promise<any>;
+        getProductTrades(productID: string, callback: callback<any>);
+        getProductTrades(productID: string, ): Promise<any>;
 
         getProductTradeStream(callback: callback<any>);
         getProductTradeStream(): Promise<any>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -153,8 +153,8 @@ declare module 'gdax' {
         getProductHistoricRates(productID: string, args: any, callback: callback<any[][]>);
         getProductHistoricRates(productID: string, args: any): Promise<any[][]>;
 
-        getProduct24HrStats(callback: callback<any>);
-        getProduct24HrStats(): Promise<any>;
+        getProduct24HrStats(productID: string, callback: callback<any>);
+        getProduct24HrStats(productID: string): Promise<any>;
 
         getCurrencies(callback: callback<CurrencyInfo[]>);
         getCurrencies(): Promise<CurrencyInfo[]>;

--- a/lib/clients/authenticated.js
+++ b/lib/clients/authenticated.js
@@ -4,7 +4,7 @@ const PublicClient = require('./public.js');
 
 class AuthenticatedClient extends PublicClient {
   constructor(key, secret, passphrase, apiURI) {
-    super('', apiURI);
+    super(apiURI);
     this.key = key;
     this.secret = secret;
     this.passphrase = passphrase;
@@ -45,7 +45,7 @@ class AuthenticatedClient extends PublicClient {
   getCoinbaseAccounts(callback) {
     return this.get(['coinbase-accounts'], callback);
   }
-  
+
   getPaymentMethods(callback) {
     return this.get(['payment-methods'], callback);
   }

--- a/lib/clients/authenticated.js
+++ b/lib/clients/authenticated.js
@@ -127,16 +127,6 @@ class AuthenticatedClient extends PublicClient {
     return this.delete(['orders'], callback);
   }
 
-  // temp over ride public call to get Product Orderbook
-  getProductOrderBook(args = {}, productId, callback) {
-    if (!callback && typeof args === 'function') {
-      callback = args;
-      args = {};
-    }
-
-    return this.get(['products', productId, 'book'], { qs: args }, callback);
-  }
-
   cancelAllOrders(args = {}, callback) {
     if (!callback && typeof args === 'function') {
       callback = args;

--- a/lib/clients/public.js
+++ b/lib/clients/public.js
@@ -1,20 +1,6 @@
 const request = require('request');
 const { Readable } = require('stream');
 
-const deprecationWarningIfProductIdMissing = (client, productID, caller) => {
-  if (!productID || typeof productID !== 'string') {
-    process.emitWarning(
-      `\`${caller}()\` now requires a product ID as the first argument. ` +
-        `Attempting to use PublicClient#productID (${
-          client.productID
-        }) instead.`,
-      'DeprecationWarning'
-    );
-  }
-};
-
-const byType = type => o => o !== null && typeof o === type;
-
 class PublicClient {
   constructor(apiURI = 'https://api.gdax.com') {
     this.productID = 'BTC-USD';
@@ -119,56 +105,52 @@ class PublicClient {
   }
 
   getProductOrderBook(productID, args, callback) {
-    deprecationWarningIfProductIdMissing(
-      this,
+    [productID, args, callback] = this._normalizeProductArgs(
       productID,
+      args,
+      callback,
       'getProductOrderBook'
     );
-
-    callback = [callback, args, productID].find(byType('function'));
-    args = [args, productID, {}].find(byType('object'));
-    productID = [productID, this.productID].find(byType('string'));
-
-    if (!productID) {
-      throw new Error('No productID specified.');
-    }
 
     const path = ['products', productID, 'book'];
     return this.get(path, { qs: args }, callback);
   }
 
   getProductTicker(productID, callback) {
-    deprecationWarningIfProductIdMissing(this, productID, 'getProductTicker');
-
-    callback = [callback, productID].find(byType('function'));
-    productID = [productID, this.productID].find(byType('string'));
+    [productID, , callback] = this._normalizeProductArgs(
+      productID,
+      null,
+      callback,
+      'getProductTicker'
+    );
 
     const path = ['products', productID, 'ticker'];
     return this.get(path, callback);
   }
 
   getProductTrades(productID, args, callback) {
-    deprecationWarningIfProductIdMissing(this, productID, 'getProductTrades');
-
-    callback = [callback, args, productID].find(byType('function'));
-    args = [args, productID, {}].find(byType('object'));
-    productID = [productID, this.productID].find(byType('string'));
+    [productID, args, callback] = this._normalizeProductArgs(
+      productID,
+      args,
+      callback,
+      'getProductTrades'
+    );
 
     const path = ['products', productID, 'trades'];
     return this.get(path, { qs: args }, callback);
   }
 
   getProductTradeStream(productID, tradesFrom, tradesTo) {
-    deprecationWarningIfProductIdMissing(
-      this,
-      productID,
-      'getProductTradeStream'
-    );
-
     if (!productID || typeof productID !== 'string') {
       [tradesFrom, tradesTo] = Array.prototype.slice.call(arguments);
     }
-    productID = [productID, this.productID].find(byType('string'));
+
+    [productID] = this._normalizeProductArgs(
+      productID,
+      null,
+      null,
+      'getProductTradeStream'
+    );
 
     let shouldStop = null;
 
@@ -247,29 +229,24 @@ class PublicClient {
   }
 
   getProductHistoricRates(productID, args, callback) {
-    deprecationWarningIfProductIdMissing(
-      this,
+    [productID, args, callback] = this._normalizeProductArgs(
       productID,
+      args,
+      callback,
       'getProductHistoricRates'
     );
-
-    callback = [callback, args, productID].find(byType('function'));
-    args = [args, productID, {}].find(byType('object'));
-    productID = [productID, this.productID].find(byType('string'));
 
     const path = ['products', productID, 'candles'];
     return this.get(path, { qs: args }, callback);
   }
 
   getProduct24HrStats(productID, callback) {
-    deprecationWarningIfProductIdMissing(
-      this,
+    [productID, , callback] = this._normalizeProductArgs(
       productID,
+      null,
+      callback,
       'getProduct24HrStats'
     );
-
-    callback = [callback, productID].find(byType('function'));
-    productID = [productID, this.productID].find(byType('string'));
 
     const path = ['products', productID, 'stats'];
     return this.get(path, callback);
@@ -282,6 +259,34 @@ class PublicClient {
   getTime(callback) {
     return this.get(['time'], callback);
   }
+
+  _normalizeProductArgs(productID, args, callback, caller) {
+    this._deprecationWarningIfProductIdMissing(productID, caller);
+
+    callback = [callback, args, productID].find(byType('function'));
+    args = [args, productID, {}].find(byType('object'));
+    productID = [productID, this.productID].find(byType('string'));
+
+    if (!productID) {
+      throw new Error('No productID specified.');
+    }
+
+    return [productID, args, callback];
+  }
+
+  _deprecationWarningIfProductIdMissing(productID, caller) {
+    if (!productID || typeof productID !== 'string') {
+      process.emitWarning(
+        `\`${caller}()\` now requires a product ID as the first argument. ` +
+          `Attempting to use PublicClient#productID (${
+            this.productID
+          }) instead.`,
+        'DeprecationWarning'
+      );
+    }
+  }
 }
+
+const byType = type => o => o !== null && typeof o === type;
 
 module.exports = exports = PublicClient;

--- a/lib/clients/public.js
+++ b/lib/clients/public.js
@@ -261,8 +261,18 @@ class PublicClient {
     return this.get(path, { qs: args }, callback);
   }
 
-  getProduct24HrStats(callback) {
-    return this.get(['products', this.productID, 'stats'], callback);
+  getProduct24HrStats(productID, callback) {
+    deprecationWarningIfProductIdMissing(
+      this,
+      productID,
+      'getProduct24HrStats'
+    );
+
+    callback = [callback, productID].find(byType('function'));
+    productID = [productID, this.productID].find(byType('string'));
+
+    const path = ['products', productID, 'stats'];
+    return this.get(path, callback);
   }
 
   getCurrencies(callback) {

--- a/lib/clients/public.js
+++ b/lib/clients/public.js
@@ -246,16 +246,19 @@ class PublicClient {
     }
   }
 
-  getProductHistoricRates(args = {}, callback) {
-    if (!callback && typeof args === 'function') {
-      callback = args;
-      args = {};
-    }
-    return this.get(
-      ['products', this.productID, 'candles'],
-      { qs: args },
-      callback
+  getProductHistoricRates(productID, args, callback) {
+    deprecationWarningIfProductIdMissing(
+      this,
+      productID,
+      'getProductHistoricRates'
     );
+
+    callback = [callback, args, productID].find(byType('function'));
+    args = [args, productID, {}].find(byType('object'));
+    productID = [productID, this.productID].find(byType('string'));
+
+    const path = ['products', productID, 'candles'];
+    return this.get(path, { qs: args }, callback);
   }
 
   getProduct24HrStats(callback) {

--- a/lib/clients/public.js
+++ b/lib/clients/public.js
@@ -104,17 +104,28 @@ class PublicClient {
     return this.get(['products'], callback);
   }
 
-  getProductOrderBook(args = {}, callback) {
-    if (!callback && typeof args === 'function') {
-      callback = args;
-      args = {};
+  getProductOrderBook(productID, args, callback) {
+    if (!productID || typeof productID !== 'string') {
+      process.emitWarning(
+        '`getProductOrderBook()` now requires a product ID as the first argument. ' +
+          `Attempting to use PublicClient#productID (${
+            this.productID
+          }) instead.`,
+        'DeprecationWarning'
+      );
     }
 
-    return this.get(
-      ['products', this.productID, 'book'],
-      { qs: args },
-      callback
-    );
+    const byType = type => o => o !== null && typeof o === type;
+    callback = [callback, args, productID].find(byType('function'));
+    args = [args, productID, {}].find(byType('object'));
+    productID = [productID, this.productID].find(byType('string'));
+
+    if (!productID) {
+      throw new Error('No productID specified.');
+    }
+
+    const path = ['products', productID, 'book'];
+    return this.get(path, { qs: args }, callback);
   }
 
   getProductTicker(callback) {

--- a/lib/clients/public.js
+++ b/lib/clients/public.js
@@ -2,8 +2,17 @@ const request = require('request');
 const { Readable } = require('stream');
 
 class PublicClient {
-  constructor(productID = 'BTC-USD', apiURI = 'https://api.gdax.com') {
-    this.productID = productID;
+  constructor(apiURI = 'https://api.gdax.com') {
+    this.productID = 'BTC-USD';
+    if (apiURI && !apiURI.startsWith('http')) {
+      process.emitWarning(
+        '`new PublicClient()` no longer accepts a product ID as the first argument. ',
+        'DeprecationWarning'
+      );
+      this.productID = apiURI;
+      apiURI = arguments[1] || 'https://api.gdax.com';
+    }
+
     this.apiURI = apiURI;
     this.API_LIMIT = 100;
   }

--- a/lib/clients/public.js
+++ b/lib/clients/public.js
@@ -1,6 +1,20 @@
 const request = require('request');
 const { Readable } = require('stream');
 
+const deprecationWarningIfProductIdMissing = (client, productID, caller) => {
+  if (!productID || typeof productID !== 'string') {
+    process.emitWarning(
+      `\`${caller}()\` now requires a product ID as the first argument. ` +
+        `Attempting to use PublicClient#productID (${
+          client.productID
+        }) instead.`,
+      'DeprecationWarning'
+    );
+  }
+};
+
+const byType = type => o => o !== null && typeof o === type;
+
 class PublicClient {
   constructor(apiURI = 'https://api.gdax.com') {
     this.productID = 'BTC-USD';
@@ -105,17 +119,12 @@ class PublicClient {
   }
 
   getProductOrderBook(productID, args, callback) {
-    if (!productID || typeof productID !== 'string') {
-      process.emitWarning(
-        '`getProductOrderBook()` now requires a product ID as the first argument. ' +
-          `Attempting to use PublicClient#productID (${
-            this.productID
-          }) instead.`,
-        'DeprecationWarning'
-      );
-    }
+    deprecationWarningIfProductIdMissing(
+      this,
+      productID,
+      'getProductOrderBook'
+    );
 
-    const byType = type => o => o !== null && typeof o === type;
     callback = [callback, args, productID].find(byType('function'));
     args = [args, productID, {}].find(byType('object'));
     productID = [productID, this.productID].find(byType('string'));
@@ -128,8 +137,14 @@ class PublicClient {
     return this.get(path, { qs: args }, callback);
   }
 
-  getProductTicker(callback) {
-    return this.get(['products', this.productID, 'ticker'], callback);
+  getProductTicker(productID, callback) {
+    deprecationWarningIfProductIdMissing(this, productID, 'getProductTicker');
+
+    callback = [callback, productID].find(byType('function'));
+    productID = [productID, this.productID].find(byType('string'));
+
+    const path = ['products', productID, 'ticker'];
+    return this.get(path, callback);
   }
 
   getProductTrades(args = {}, callback) {

--- a/lib/clients/public.js
+++ b/lib/clients/public.js
@@ -158,7 +158,18 @@ class PublicClient {
     return this.get(path, { qs: args }, callback);
   }
 
-  getProductTradeStream(tradesFrom, tradesTo) {
+  getProductTradeStream(productID, tradesFrom, tradesTo) {
+    deprecationWarningIfProductIdMissing(
+      this,
+      productID,
+      'getProductTradeStream'
+    );
+
+    if (!productID || typeof productID !== 'string') {
+      [tradesFrom, tradesTo] = Array.prototype.slice.call(arguments);
+    }
+    productID = [productID, this.productID].find(byType('string'));
+
     let shouldStop = null;
 
     if (typeof tradesTo === 'function') {
@@ -189,7 +200,7 @@ class PublicClient {
 
       let opts = { before: tradesFrom, after: after, limit: this.API_LIMIT };
 
-      this.getProductTrades(opts, (err, resp, data) => {
+      this.getProductTrades(productID, opts, (err, resp, data) => {
         if (err) {
           stream.emit('error', err);
           return;

--- a/lib/clients/public.js
+++ b/lib/clients/public.js
@@ -147,16 +147,15 @@ class PublicClient {
     return this.get(path, callback);
   }
 
-  getProductTrades(args = {}, callback) {
-    if (!callback && typeof args === 'function') {
-      callback = args;
-      args = {};
-    }
-    return this.get(
-      ['products', this.productID, 'trades'],
-      { qs: args },
-      callback
-    );
+  getProductTrades(productID, args, callback) {
+    deprecationWarningIfProductIdMissing(this, productID, 'getProductTrades');
+
+    callback = [callback, args, productID].find(byType('function'));
+    args = [args, productID, {}].find(byType('object'));
+    productID = [productID, this.productID].find(byType('string'));
+
+    const path = ['products', productID, 'trades'];
+    return this.get(path, { qs: args }, callback);
   }
 
   getProductTradeStream(tradesFrom, tradesTo) {

--- a/lib/orderbook_sync.js
+++ b/lib/orderbook_sync.js
@@ -18,16 +18,17 @@ class OrderbookSync extends WebsocketClient {
 
     this._queues = {}; // []
     this._sequences = {}; // -1
-    this._public_clients = {};
     this.books = {};
 
     if (this.auth.secret) {
-      this._authenticatedClient = new AuthenticatedClient(
+      this._client = new AuthenticatedClient(
         this.auth.key,
         this.auth.secret,
         this.auth.passphrase,
         this.apiURI
       );
+    } else {
+      this._client = new PublicClient(this.apiURI);
     }
 
     this.productIDs.forEach(productID => {
@@ -62,26 +63,10 @@ class OrderbookSync extends WebsocketClient {
       return;
     }
 
-    const bookLevel = 3;
-    const args = { level: bookLevel };
-
-    if (this._authenticatedClient) {
-      this._authenticatedClient
-        .getProductOrderBook(args, productID)
-        .then(onData.bind(this))
-        .catch(onError.bind(this));
-    } else {
-      if (!this._public_clients[productID]) {
-        this._public_clients[productID] = new PublicClient(
-          productID,
-          this.apiURI
-        );
-      }
-      this._public_clients[productID]
-        .getProductOrderBook(args)
-        .then(onData.bind(this))
-        .catch(onError.bind(this));
-    }
+    this._client
+      .getProductOrderBook(productID, { level: 3 })
+      .then(onData.bind(this))
+      .catch(onError.bind(this));
 
     function onData(data) {
       this.books[productID].state(data);

--- a/tests/authenticated.spec.js
+++ b/tests/authenticated.spec.js
@@ -343,38 +343,6 @@ suite('AuthenticatedClient', () => {
       .catch(err => assert.ifError(err) || assert.fail());
   });
 
-  test('.getProductOrderBook()', done => {
-    nock(EXCHANGE_API_URL)
-      .get('/products/BTC-USD/book?level=3')
-      .times(2)
-      .reply(200, {
-        asks: [],
-        bids: [],
-      });
-
-    let cbtest = new Promise((resolve, reject) => {
-      authClient.getProductOrderBook(
-        { level: 3 },
-        'BTC-USD',
-        (err, resp, data) => {
-          if (err) {
-            reject(err);
-          }
-          assert(data);
-          resolve();
-        }
-      );
-    });
-
-    let promisetest = authClient
-      .getProductOrderBook({ level: 3 }, 'BTC-USD')
-      .then(data => assert(data));
-
-    Promise.all([cbtest, promisetest])
-      .then(() => done())
-      .catch(err => assert.ifError(err) || assert.fail());
-  });
-
   suite('.cancelAllOrders()', () => {
     test('cancels all orders', () => {
       const cancelledOrdersOne = [

--- a/tests/public_client.spec.js
+++ b/tests/public_client.spec.js
@@ -112,9 +112,9 @@ suite('PublicClient', () => {
       .catch(err => assert.isError(err) || assert.fail());
   });
 
-  test('.getProductTicker() should return values', done => {
+  test('.getProductTicker()', () => {
     nock(EXCHANGE_API_URL)
-      .get('/products/BTC-USD/ticker')
+      .get('/products/ETH-USD/ticker')
       .times(2)
       .reply(200, {
         trade_id: 'test-id',
@@ -122,8 +122,8 @@ suite('PublicClient', () => {
         size: '5',
       });
 
-    let cbtest = new Promise((resolve, reject) => {
-      publicClient.getProductTicker((err, resp, data) => {
+    const cbtest = new Promise((resolve, reject) => {
+      publicClient.getProductTicker('ETH-USD', (err, resp, data) => {
         if (err) {
           reject(err);
         }
@@ -136,15 +136,30 @@ suite('PublicClient', () => {
       });
     });
 
-    let promisetest = publicClient.getProductTicker().then(data => {
+    const promisetest = publicClient.getProductTicker('ETH-USD').then(data => {
       assert.equal(data.trade_id, 'test-id');
       assert.equal(data.price, '9.00');
       assert.equal(data.size, '5');
     });
 
-    Promise.all([cbtest, promisetest])
-      .then(() => done())
-      .catch(err => assert.isError(err) || assert.fail());
+    return Promise.all([cbtest, promisetest]);
+  });
+
+  // Delete this test when the deprecation is final
+  test('.getProductTicker() (with deprecated signature implying default product ID)', () => {
+    nock(EXCHANGE_API_URL)
+      .get('/products/BTC-USD/ticker')
+      .reply(200, {
+        trade_id: 'test-id',
+        price: '90.00',
+        size: '2',
+      });
+
+    return publicClient.getProductTicker().then(data => {
+      assert.equal(data.trade_id, 'test-id');
+      assert.equal(data.price, '90.00');
+      assert.equal(data.size, '2');
+    });
   });
 
   suite('.getProductTradeStream()', () => {

--- a/tests/public_client.spec.js
+++ b/tests/public_client.spec.js
@@ -70,7 +70,7 @@ suite('PublicClient', () => {
       .then(data => assert(data));
   });
 
-  test('.getProductTrades()', done => {
+  test('.getProductTrades()', () => {
     const expectedResponse = [
       {
         time: '2014-11-07T22:19:28.578544Z',
@@ -89,12 +89,12 @@ suite('PublicClient', () => {
     ];
 
     nock(EXCHANGE_API_URL)
-      .get('/products/BTC-USD/trades')
+      .get('/products/LTC-USD/trades')
       .times(2)
       .reply(200, expectedResponse);
 
-    let cbtest = new Promise((resolve, reject) => {
-      publicClient.getProductTrades((err, resp, data) => {
+    const cbtest = new Promise((resolve, reject) => {
+      publicClient.getProductTrades('LTC-USD', (err, resp, data) => {
         if (err) {
           reject(err);
         }
@@ -103,13 +103,32 @@ suite('PublicClient', () => {
       });
     });
 
-    let promisetest = publicClient
-      .getProductTrades()
+    const promisetest = publicClient
+      .getProductTrades('LTC-USD')
       .then(data => assert.deepEqual(data, expectedResponse));
 
-    Promise.all([cbtest, promisetest])
-      .then(() => done())
-      .catch(err => assert.isError(err) || assert.fail());
+    return Promise.all([cbtest, promisetest]);
+  });
+
+  // Delete this test when the deprecation is final
+  test('.getProductTrades() (with deprecated signature implying default product ID)', () => {
+    const expectedResponse = [
+      {
+        time: '2014-11-07T22:19:28.578544Z',
+        trade_id: 74,
+        price: '10.00000000',
+        size: '0.01000000',
+        side: 'buy',
+      },
+    ];
+
+    nock(EXCHANGE_API_URL)
+      .get('/products/BTC-USD/trades')
+      .reply(200, expectedResponse);
+
+    return publicClient
+      .getProductTrades()
+      .then(data => assert.deepEqual(data, expectedResponse));
   });
 
   test('.getProductTicker()', () => {

--- a/tests/public_client.spec.js
+++ b/tests/public_client.spec.js
@@ -26,6 +26,50 @@ suite('PublicClient', () => {
     assert.equal(client.productID, 'LTC-USD');
   });
 
+  test('.getProductOrderBook()', () => {
+    nock(EXCHANGE_API_URL)
+      .get('/products/LTC-USD/book?level=3')
+      .times(2)
+      .reply(200, {
+        asks: [],
+        bids: [],
+      });
+
+    const cbtest = new Promise((resolve, reject) => {
+      publicClient.getProductOrderBook(
+        'LTC-USD',
+        { level: 3 },
+        (err, resp, data) => {
+          if (err) {
+            reject(err);
+          }
+          assert(data);
+          resolve();
+        }
+      );
+    });
+
+    const promisetest = publicClient
+      .getProductOrderBook('LTC-USD', { level: 3 })
+      .then(data => assert(data));
+
+    return Promise.all([cbtest, promisetest]);
+  });
+
+  // Delete this test when the deprecation is final
+  test('.getProductOrderBook() (with deprecated signature implying default product ID)', () => {
+    nock(EXCHANGE_API_URL)
+      .get('/products/BTC-USD/book?level=2')
+      .reply(200, {
+        asks: [],
+        bids: [],
+      });
+
+    return publicClient
+      .getProductOrderBook({ level: 2 })
+      .then(data => assert(data));
+  });
+
   test('.getProductTrades()', done => {
     const expectedResponse = [
       {
@@ -69,11 +113,14 @@ suite('PublicClient', () => {
   });
 
   test('.getProductTicker() should return values', done => {
-    nock(EXCHANGE_API_URL).get('/products/BTC-USD/ticker').times(2).reply(200, {
-      trade_id: 'test-id',
-      price: '9.00',
-      size: '5',
-    });
+    nock(EXCHANGE_API_URL)
+      .get('/products/BTC-USD/ticker')
+      .times(2)
+      .reply(200, {
+        trade_id: 'test-id',
+        price: '9.00',
+        size: '5',
+      });
 
     let cbtest = new Promise((resolve, reject) => {
       publicClient.getProductTicker((err, resp, data) => {

--- a/tests/public_client.spec.js
+++ b/tests/public_client.spec.js
@@ -346,4 +346,62 @@ suite('PublicClient', () => {
       assert.equal(data[2][0], 1514273100);
     });
   });
+
+  test('.getProduct24HrStats()', () => {
+    nock(EXCHANGE_API_URL)
+      .get('/products/ETH-USD/stats')
+      .times(2)
+      .reply(200, {
+        open: '720',
+        high: '770',
+        low: '710',
+        volume: '110000',
+        last: '760',
+        volume_30day: '9800000',
+      });
+
+    const cbtest = new Promise((resolve, reject) => {
+      publicClient.getProduct24HrStats('ETH-USD', (err, resp, data) => {
+        if (err) {
+          reject(err);
+        }
+
+        assert.equal(data.open, 720);
+        assert.equal(data.high, 770);
+        assert.equal(data.volume, 110000);
+
+        resolve();
+      });
+    });
+
+    const promisetest = publicClient
+      .getProduct24HrStats('ETH-USD')
+      .then(data => {
+        assert.equal(data.open, 720);
+        assert.equal(data.high, 770);
+        assert.equal(data.volume, 110000);
+      });
+
+    return Promise.all([cbtest, promisetest]);
+  });
+
+  // Delete this test when the deprecation is final
+  test('.getProduct24HrStats() (with deprecated signature implying default product ID)', () => {
+    nock(EXCHANGE_API_URL)
+      .get('/products/BTC-USD/stats')
+      .reply(200, {
+        open: '14000',
+        high: '15700',
+        low: '13800',
+        volume: '17400',
+        last: '15300',
+        volume_30day: '1100000',
+      });
+
+    return publicClient.getProduct24HrStats().then(data => {
+      assert.equal(data.open, 14000);
+      assert.equal(data.high, 15700);
+      assert.equal(data.volume, 17400);
+    });
+  });
 });

--- a/tests/public_client.spec.js
+++ b/tests/public_client.spec.js
@@ -192,6 +192,34 @@ suite('PublicClient', () => {
       let current;
 
       publicClient
+        .getProductTradeStream('BTC-USD', from, to)
+        .on('data', data => {
+          current = data.trade_id;
+          assert.equal(typeof current, 'number');
+          assert.equal(
+            current,
+            last + 1,
+            current + ' is next in series, last: ' + last
+          );
+          last = current;
+        })
+        .on('end', () => {
+          assert((current = to - 1));
+          done();
+        })
+        .on('error', err => {
+          assert.fail(err);
+        });
+    });
+
+    // Delete this test when the deprecation is final
+    test('streams trades (with deprecated signature implying default product ID)', done => {
+      nock.load('./tests/mocks/pubclient_stream_trades.json');
+
+      let last = from;
+      let current;
+
+      publicClient
         .getProductTradeStream(from, to)
         .on('data', data => {
           current = data.trade_id;
@@ -219,6 +247,7 @@ suite('PublicClient', () => {
 
       publicClient
         .getProductTradeStream(
+          'BTC-USD',
           from,
           trade => Date.parse(trade.time) >= 1463068800000
         )
@@ -245,6 +274,7 @@ suite('PublicClient', () => {
 
       publicClient
         .getProductTradeStream(
+          'BTC-USD',
           from,
           trade => Date.parse(trade.time) >= Date.now()
         )

--- a/tests/public_client.spec.js
+++ b/tests/public_client.spec.js
@@ -9,6 +9,23 @@ const EXCHANGE_API_URL = 'https://api.gdax.com';
 suite('PublicClient', () => {
   afterEach(() => nock.cleanAll());
 
+  test('.constructor()', () => {
+    let client = new Gdax.PublicClient();
+    assert.equal(client.apiURI, EXCHANGE_API_URL);
+    assert.equal(client.API_LIMIT, 100);
+    assert.equal(client.productID, 'BTC-USD'); // deprecated
+
+    client = new Gdax.PublicClient('https://api-public.sandbox.gdax.com');
+    assert.equal(client.apiURI, 'https://api-public.sandbox.gdax.com');
+  });
+
+  // Delete this test when the deprecation is final
+  test('.constructor() (with deprecated signature accepting a product ID)', () => {
+    let client = new Gdax.PublicClient('LTC-USD');
+    assert.equal(client.apiURI, EXCHANGE_API_URL);
+    assert.equal(client.productID, 'LTC-USD');
+  });
+
   test('.getProductTrades()', done => {
     const expectedResponse = [
       {

--- a/tests/public_client.spec.js
+++ b/tests/public_client.spec.js
@@ -294,4 +294,56 @@ suite('PublicClient', () => {
         });
     });
   });
+
+  test('.getProductHistoricRates()', () => {
+    nock(EXCHANGE_API_URL)
+      .get('/products/ETH-USD/candles')
+      .times(2)
+      .reply(200, [
+        [1514273340, 759.75, 759.97, 759.75, 759.97, 8.03891157],
+        [1514273280, 758.99, 759.74, 758.99, 759.74, 17.36616621],
+        [1514273220, 758.99, 759, 759, 759, 10.6524787],
+      ]);
+
+    const cbtest = new Promise((resolve, reject) => {
+      publicClient.getProductHistoricRates('ETH-USD', (err, resp, data) => {
+        if (err) {
+          reject(err);
+        }
+
+        assert.equal(data[0][0], 1514273340);
+        assert.equal(data[0][1], 759.75);
+        assert.equal(data[2][0], 1514273220);
+
+        resolve();
+      });
+    });
+
+    const promisetest = publicClient
+      .getProductHistoricRates('ETH-USD')
+      .then(data => {
+        assert.equal(data[0][0], 1514273340);
+        assert.equal(data[0][1], 759.75);
+        assert.equal(data[2][0], 1514273220);
+      });
+
+    return Promise.all([cbtest, promisetest]);
+  });
+
+  // Delete this test when the deprecation is final
+  test('.getProductHistoricRates() (with deprecated signature implying default product ID)', () => {
+    nock(EXCHANGE_API_URL)
+      .get('/products/BTC-USD/candles')
+      .reply(200, [
+        [1514273220, 15399.99, 15400, 15399, 15399, 0.369797],
+        [1514273160, 15399.99, 15400, 15400, 15400, 0.673643],
+        [1514273100, 15399.99, 15400, 15400, 15400, 0.849436],
+      ]);
+
+    return publicClient.getProductHistoricRates().then(data => {
+      assert.equal(data[0][0], 1514273220);
+      assert.equal(data[0][1], 15399.99);
+      assert.equal(data[2][0], 1514273100);
+    });
+  });
 });


### PR DESCRIPTION
## What does it do?

- **Deprecates `productID` argument in `PublicClient` constructor**
- Requires `productID` as first argument to `getProductOrderBook()` and deprecates old usage signature
- Removes redundant `AuthenticatedClient#getProductOrderBook()` override
- Simplifies `OrderbookSync#loadOrderbook()` because both clients now adhere to the same method signature
- Requires `productID` as first argument to `getProductTicker()` and deprecates old usage signature
- Requires `productID` as first argument to `getProductTrades()` and deprecates old usage signature
- Requires `productID` as first argument to `getProductTradeStream()` and deprecates old usage signature
- Requires `productID` as first argument to `getProductHistoricRates()` and deprecates old usage signature
- Requires `productID` as first argument to `getProduct24HrStats()` and deprecates old usage signature
- Consolidates deprecation & argument normalization logic in `PublicClient` to later simplify the eventual transition of outright removing the (now unnecessary) `PublicClient#productID` property.
- Updates the TypeScript definitions to match
- Updates the `README` documentation to match
- **Includes several tests that were missing**
- **Includes backwards compatibility tests for all deprecated method signatures**

## What else do you need to know?

- **Any use of a deprecated method signature will emit a warning**
- The general idea is that `PublicClient` should no longer maintain state about a particular product ID.
- Any method that can be called on a `PublicClient` instance can now also be called on an `AuthenticatedClient` instance.  In other words, the classes now correctly adhere to the specification in the `README`:
    > _"`AuthenticatedClient` inherits all of the API methods from `PublicClient`, so if you're hitting both public and private API endpoints you only need to create a single client."_

## Related Issues and PRs

- Fixes #46
- Fixes #117
- Fixes #158
- Closes #83 (this PR supersedes)
- Closes #131 (this PR supersedes)

## Communication

- Because this is a fairly large PR, **I recommend code-reviewing the changes for each commit individually instead of reviewing the entire PR at once.** It's likely easier to digest that way.

- **I think it would be prudent to make an interim v0.x release with these changes, thereby documenting and committing to all the deprecations. That would allow for a full cleanup during an eventual v1.0 release where the old method signatures and deprecations are removed, and the new method signature win-out.**

/cc @fb55 
