### PR TITLE
Remove disclaimers from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,6 @@
 
 The official Node.js library for Coinbase's [GDAX API](https://docs.gdax.com/).
 
-*Note: this library may be subtly broken or buggy. The code is released under
-the MIT License – please take the following message to heart:*
-
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-> SOFTWARE.
-
 ## Features
 
 * Easy functionality to use in programmatic trading
@@ -20,7 +9,6 @@ the MIT License – please take the following message to heart:*
 * API clients with convenient methods for every API endpoint
 * Abstracted interfaces – don't worry about HMAC signing or JSON formatting; the
   library does it for you
-* Semantic versioning
 
 ## Installation
 


### PR DESCRIPTION
**Extracted from PR #83**

- Disclaimers are already covered by the official MIT LICENSE
- Semantic versioning isn't a feature; it's an expectation of all good software libraries. 

/cc @fb55 