### PR TITLE
Update gitignore and CircleCI node version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules
 
 /.idea
 /package-lock.json
+/yarn.lock
+/.node-version

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,3 @@
 machine:
   node:
-    version: 6.1.0
+    version: 6.12.2


### PR DESCRIPTION
- Adds `yarn.lock` and `.node-version` to `.gitignore` (two common tools that people use, but the config files don't belong in the repository for a shared library)
- Updates `circle.yml` to rely on latest Node v6 LTS version (v6.12.2)

/cc @fb55 
