### PR TITLE
Make WebsocketClient#on signature generic

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -253,7 +253,7 @@ declare module 'gdax' {
             auth?: {key:string, secret:string, passphrase:string},
             { channels }?: WebsocketClientOptions );
 
-        on(event: 'message', eventHandler: (data:object) => void);
+        on<T>(event: 'message', eventHandler: (data:T) => void);
         on(event: 'error', eventHandler: (err) => void);
         on(event: 'open', eventHandler: () => void);
         on(event: 'close', eventHandler: () => void);


### PR DESCRIPTION
![error](https://user-images.githubusercontent.com/3489757/34451884-3cdce730-ed34-11e7-8165-7f6a81ba141f.png)

I've got troubles with the signature of `WebsocketClient#on` method.
Apparently it conflicts with one of its overload. I find in this case more useful the adoption of a generic types.

Any thoughts?