### PR TITLE
Bugfix/sync server time

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -93,6 +93,9 @@ declare module 'gdax' {
             limit: number;
         };
 
+    export type BoolResult = {
+        success: boolean
+    };
 
     export type Account = {
         id: string,
@@ -165,6 +168,9 @@ declare module 'gdax' {
 
     export class AuthenticatedClient {
         constructor(key: string, secret: string, passphrase: string, apiURI: string);
+
+        startSynchronizingWithServer(frequencyMilliseconds: number, callback: callback<BoolResult>);
+        stopSynchronizingWithServer();
 
         getCoinbaseAccounts(callback: callback<CoinbaseAccount[]>)
         getCoinbaseAccounts(): Promise<CoinbaseAccount[]>;

--- a/lib/clients/authenticated.js
+++ b/lib/clients/authenticated.js
@@ -8,6 +8,7 @@ class AuthenticatedClient extends PublicClient {
     this.key = key;
     this.secret = secret;
     this.passphrase = passphrase;
+    this.serverOffsetSeconds = 0;
   }
 
   request(method, uriParts, opts = {}, callback) {
@@ -29,7 +30,9 @@ class AuthenticatedClient extends PublicClient {
   }
 
   _getSignature(method, relativeURI, opts) {
-    const sig = signRequest(this, method, relativeURI, opts);
+    const timestamp = Date.now() / 1000 - this.serverOffsetSeconds;
+    const sig = signRequest(this, method, relativeURI, timestamp, opts);
+
 
     if (opts.body) {
       opts.body = JSON.stringify(opts.body);
@@ -40,6 +43,38 @@ class AuthenticatedClient extends PublicClient {
       'CB-ACCESS-TIMESTAMP': sig.timestamp,
       'CB-ACCESS-PASSPHRASE': sig.passphrase,
     };
+  }
+
+  startSynchronizingWithServer(frequencyMilliseconds, callback) {
+    if (this.syncInterval) {
+      err = new Error("Synchronization is already started.");
+      callback(err, null, null);
+    }
+    else {
+      const timeCallback = (err, response, data) => {
+        if (err || !('epoch' in data)) {
+          callback(err, response, { success : false });
+        }
+        else {
+          this.serverOffsetSeconds = Date.now() / 1000 - data.epoch;
+          callback(err, response, { success : true });
+        }
+      };
+
+      this.getTime(timeCallback);
+
+      this.syncInterval = setInterval(() => {
+        this.getTime(timeCallback);
+      }, frequencyMilliseconds);
+    }
+  }
+
+  stopSynchronizingWithServer(frequencyMilliseconds) {
+    if (this.syncInterval) {
+      clearInterval(this.syncInterval);
+      this.syncInterval = null;
+      this.serverOffsetSeconds = 0;
+    }
   }
 
   getCoinbaseAccounts(callback) {

--- a/lib/clients/authenticated.js
+++ b/lib/clients/authenticated.js
@@ -47,7 +47,7 @@ class AuthenticatedClient extends PublicClient {
 
   startSynchronizingWithServer(frequencyMilliseconds, callback) {
     if (this.syncInterval) {
-      err = new Error("Synchronization is already started.");
+      const err = new Error("Synchronization is already started.");
       callback(err, null, null);
     }
     else {
@@ -69,7 +69,7 @@ class AuthenticatedClient extends PublicClient {
     }
   }
 
-  stopSynchronizingWithServer(frequencyMilliseconds) {
+  stopSynchronizingWithServer() {
     if (this.syncInterval) {
       clearInterval(this.syncInterval);
       this.syncInterval = null;

--- a/lib/clients/websocket.js
+++ b/lib/clients/websocket.js
@@ -62,7 +62,8 @@ class WebsocketClient extends EventEmitter {
       let sig = signRequest(
         this.auth,
         'GET',
-        this.channels ? '/users/self/verify' : '/users/self'
+        this.channels ? '/users/self/verify' : '/users/self',
+        Date.now() / 1000
       );
       Object.assign(subscribeMessage, sig);
     }

--- a/lib/request_signer.js
+++ b/lib/request_signer.js
@@ -11,8 +11,7 @@ const querystring = require('querystring');
  * @param options.qs {object} A hash of query string parameters
  * @returns {{key: string, signature: *, timestamp: number, passphrase: string}}
  */
-module.exports.signRequest = (auth, method, path, options = {}) => {
-  const timestamp = Date.now() / 1000;
+module.exports.signRequest = (auth, method, path, timestamp, options = {}) => {
   let body = '';
   if (options.body) {
     body = JSON.stringify(options.body);

--- a/tests/authenticated.spec.js
+++ b/tests/authenticated.spec.js
@@ -31,6 +31,23 @@ suite('AuthenticatedClient', () => {
     assert(sig['CB-ACCESS-SIGN']);
   });
 
+  test('.startSynchronizingWithServer()', done => {
+    const fiveMinutesMillis = 5 * 60 * 1000;
+    const now = new Date();
+    const expectedResponse = { 'iso' : now.toISOString(), 'epoch' : now.getTime() / 1000}
+
+    nock(EXCHANGE_API_URL)
+      .get('/time')
+      .reply(200, expectedResponse);
+
+    authClient.startSynchronizingWithServer(fiveMinutesMillis, (err, response, data) => {
+      assert.ifError(err);
+      assert(data.success === true);
+      authClient.stopSynchronizingWithServer();
+      done();
+    });
+  });
+
   test('.getCoinbaseAccounts()', done => {
     const expectedResponse = [
       {


### PR DESCRIPTION
This synchronizes the time with the server when using the authenticated client. My computer is 70 seconds behind gdax's server, so I was getting `{ message: 'request timestamp expired' }` in the data field every time I called an authenticated api call.

I added two new functions. `startSynchronizingWithServer` calls the time api every `frequencyMilliseconds` to update a time offset variable from the server that can be used when signing requests. Each time this happens, the supplied callback is called to let the user know if synchronization is working. `stopSynchronizingWithServer` turns off this functionality and sets the time offset variable to 0.

I had originally called the time api when an authenticated request was made if `frequencyMilliseconds` had elapsed, but I think this is cleaner.

This pull request does not address the websocket api. I still can't access the authenticated websocket api because of timeouts.

I can update the readme as well to provide information on synchronizing the time with the server's. This is a simplistic example of using the new functions:

```
const Gdax = require('gdax');

const key = 'key';
const secret = 'secret';
const passphrase = 'passphrase';
const apiURI = 'https://api.gdax.com';

const authedClient = new Gdax.AuthenticatedClient(key, secret, passphrase, apiURI);

function startRunning() {
  authedClient.getAccounts().then(data => console.log(data));
}
  
let isSynchronized = false;
const syncTimeMillis = 5 * 60 * 1000;

authedClient.startSynchronizingWithServer(syncTimeMillis, (err, response, data) => {
  if (!isSynchronized && !err && data.success === true) {
    isSynchronized = true;
    startRunning();
  }
});
```