### PR TITLE
Add a default timeout to each request

### DIFF
--- a/lib/clients/authenticated.js
+++ b/lib/clients/authenticated.js
@@ -3,8 +3,8 @@ const { signRequest } = require('../../lib/request_signer');
 const PublicClient = require('./public.js');
 
 class AuthenticatedClient extends PublicClient {
-  constructor(key, secret, passphrase, apiURI) {
-    super(apiURI);
+  constructor(key, secret, passphrase, apiURI, options = {}) {
+    super(apiURI, options);
     this.key = key;
     this.secret = secret;
     this.passphrase = passphrase;

--- a/lib/clients/public.js
+++ b/lib/clients/public.js
@@ -1,8 +1,9 @@
 const request = require('request');
 const { Readable } = require('stream');
+const DEFAULT_TIMEOUT = 10 * 1000; // 10 sec
 
 class PublicClient {
-  constructor(apiURI = 'https://api.gdax.com') {
+  constructor(apiURI = 'https://api.gdax.com', options = {}) {
     this.productID = 'BTC-USD';
     if (apiURI && !apiURI.startsWith('http')) {
       process.emitWarning(
@@ -15,6 +16,7 @@ class PublicClient {
 
     this.apiURI = apiURI;
     this.API_LIMIT = 100;
+    this.timeout = +options.timeout > 0 ? options.timeout : DEFAULT_TIMEOUT;
   }
 
   get(...args) {
@@ -86,6 +88,7 @@ class PublicClient {
       method: method.toUpperCase(),
       uri: this.makeAbsoluteURI(this.makeRelativeURI(uriParts)),
       qsStringifyOptions: { arrayFormat: 'repeat' },
+      timeout: this.timeout,
     });
     this.addHeaders(opts);
     const p = new Promise((resolve, reject) => {
@@ -278,9 +281,8 @@ class PublicClient {
     if (!productID || typeof productID !== 'string') {
       process.emitWarning(
         `\`${caller}()\` now requires a product ID as the first argument. ` +
-          `Attempting to use PublicClient#productID (${
-            this.productID
-          }) instead.`,
+          `Attempting to use PublicClient#productID (${this
+            .productID}) instead.`,
         'DeprecationWarning'
       );
     }

--- a/lib/clients/public.js
+++ b/lib/clients/public.js
@@ -281,8 +281,9 @@ class PublicClient {
     if (!productID || typeof productID !== 'string') {
       process.emitWarning(
         `\`${caller}()\` now requires a product ID as the first argument. ` +
-          `Attempting to use PublicClient#productID (${this
-            .productID}) instead.`,
+          `Attempting to use PublicClient#productID (${
+            this.productID
+          }) instead.`,
         'DeprecationWarning'
       );
     }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "lint-staged": "^3.6.1",
     "mocha": "3.4.2",
     "nock": "9.0.13",
-    "prettier": "^1.4.4"
+    "prettier": "^1.9.2"
   },
   "directories": {
     "lib": "./lib"

--- a/tests/public_client.spec.js
+++ b/tests/public_client.spec.js
@@ -14,6 +14,7 @@ suite('PublicClient', () => {
     assert.equal(client.apiURI, EXCHANGE_API_URL);
     assert.equal(client.API_LIMIT, 100);
     assert.equal(client.productID, 'BTC-USD'); // deprecated
+    assert.equal(client.timeout, 10000);
 
     client = new Gdax.PublicClient('https://api-public.sandbox.gdax.com');
     assert.equal(client.apiURI, 'https://api-public.sandbox.gdax.com');


### PR DESCRIPTION
`request` doesn't have a default timeout set. 
If GDAX API servers time out, the connection will stay open and the callbacks for HTTP requests will never be called leaving requests in limbo.

This PR adds a default timeout of 10s to all requests and adds an option to set the value in the constructor.