### PR TITLE
Change granularity parameter in README to an acceptable input.

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ const trades = publicClient.getProductTradeStream('BTC-USD', 8408000, trade => D
 publicClient.getProductHistoricRates('BTC-USD', callback);
 
 // To include extra parameters:
-publicClient.getProductHistoricRates('BTC-USD', { granularity: 3000 }, callback);
+publicClient.getProductHistoricRates('BTC-USD', { granularity: 3600 }, callback);
 ```
 
 * [`getProduct24HrStats`](https://docs.gdax.com/#get-24hr-stats)


### PR DESCRIPTION
The value '3000' is not an acceptable input for the granularity parameter of getProductHistoricRates. From the [API documentation](https://docs.gdax.com/#get-historic-rates):

> The granularity field must be one of the following values: {60, 300, 900, 3600, 21600, 86400}. Otherwise, your request will be rejected.