### PR TITLE
Fix request error handling

### DIFF
--- a/lib/clients/authenticated.js
+++ b/lib/clients/authenticated.js
@@ -139,9 +139,7 @@ class AuthenticatedClient extends PublicClient {
     const p = function deleteNext() {
       return new Promise((resolve, reject) => {
         this.delete(['orders'], opts, (err, response, data) => {
-          if (err || data === null) {
-            err = err || new Error('Could not delete all orders');
-            err.response = response;
+          if (err) {
             reject(err);
           } else {
             resolve([response, data]);

--- a/lib/clients/public.js
+++ b/lib/clients/public.js
@@ -58,22 +58,28 @@ class PublicClient {
       } catch (e) {
         data = null;
       }
-      if (typeof callback === 'function') {
-        callback(err, response, data);
-        return;
-      }
+
       if (err) {
         err.response = response;
-        reject(err);
-      }
-      if (data === null) {
+      } else if (response.statusCode > 299) {
+        err = new Error(`HTTP ${response.statusCode} Error`);
+        err.response = response;
+        err.data = data;
+      } else if (data === null) {
         err = new Error('Response could not be parsed as JSON');
         err.response = response;
-        reject(err);
-      } else if (response.statusCode < 200 || response.statusCode >= 400) {
-        err = new Error('Received an error response');
-        err.response = response;
-        err.data = data
+      }
+
+      if (typeof callback === 'function') {
+        if (err) {
+          callback(err);
+        } else {
+          callback(null, response, data);
+        }
+        return;
+      }
+
+      if (err) {
         reject(err);
       } else {
         resolve(data);

--- a/lib/clients/public.js
+++ b/lib/clients/public.js
@@ -70,6 +70,11 @@ class PublicClient {
         err = new Error('Response could not be parsed as JSON');
         err.response = response;
         reject(err);
+      } else if (response.statusCode < 200 || response.statusCode >= 400) {
+        err = new Error('Received an error response');
+        err.response = response;
+        err.data = data
+        reject(err);
       } else {
         resolve(data);
       }

--- a/lib/clients/public.js
+++ b/lib/clients/public.js
@@ -62,7 +62,9 @@ class PublicClient {
       if (err) {
         err.response = response;
       } else if (response.statusCode > 299) {
-        err = new Error(`HTTP ${response.statusCode} Error`);
+        err = new Error(
+          `HTTP ${response.statusCode} Error: ${data && data.message}`
+        );
         err.response = response;
         err.data = data;
       } else if (data === null) {

--- a/tests/authenticated.spec.js
+++ b/tests/authenticated.spec.js
@@ -405,11 +405,13 @@ suite('AuthenticatedClient', () => {
       nock(EXCHANGE_API_URL)
         .delete('/orders')
         .times(2)
-        .reply(404, null);
+        .reply(400, { message: 'some error' });
 
-      let cbTest = new Promise((resolve, reject) => {
+      const cbtest = new Promise((resolve, reject) => {
         authClient.cancelAllOrders(err => {
           if (err) {
+            assert.equal(err.response.statusCode, 400);
+            assert.equal(err.data.message, 'some error');
             resolve();
           } else {
             reject();
@@ -417,12 +419,15 @@ suite('AuthenticatedClient', () => {
         });
       });
 
-      return cbTest
-        .then(() => {
-          return authClient.cancelAllOrders();
-        })
+      const promisetest = authClient
+        .cancelAllOrders()
         .then(() => assert.fail('should have thrown an error'))
-        .catch(err => assert(err));
+        .catch(err => {
+          assert.equal(err.response.statusCode, 400);
+          assert.equal(err.data.message, 'some error');
+        });
+
+      return Promise.all([cbtest, promisetest]);
     });
   });
 

--- a/tests/public_client.spec.js
+++ b/tests/public_client.spec.js
@@ -36,7 +36,7 @@ suite('PublicClient', () => {
       const cbtest = new Promise((resolve, reject) => {
         publicClient.request('get', ['some', 'path'], {}, err => {
           if (err) {
-            assert.equal(err.message, 'HTTP 400 Error');
+            assert.equal(err.message, 'HTTP 400 Error: some error');
             assert.equal(err.response.statusCode, 400);
             assert.equal(err.data.message, 'some error');
             resolve();
@@ -50,7 +50,7 @@ suite('PublicClient', () => {
         .request('get', ['some', 'path'])
         .then(() => assert.fail('should have thrown an error'))
         .catch(err => {
-          assert.equal(err.message, 'HTTP 400 Error');
+          assert.equal(err.message, 'HTTP 400 Error: some error');
           assert.equal(err.response.statusCode, 400);
           assert(err.data.message, 'some error');
         });

--- a/tests/public_client.spec.js
+++ b/tests/public_client.spec.js
@@ -26,6 +26,39 @@ suite('PublicClient', () => {
     assert.equal(client.productID, 'LTC-USD');
   });
 
+  suite('.request()', () => {
+    test('handles errors', () => {
+      nock(EXCHANGE_API_URL)
+        .get('/some/path')
+        .times(2)
+        .reply(400, { message: 'some error' });
+
+      const cbtest = new Promise((resolve, reject) => {
+        publicClient.request('get', ['some', 'path'], {}, err => {
+          if (err) {
+            assert.equal(err.message, 'HTTP 400 Error');
+            assert.equal(err.response.statusCode, 400);
+            assert.equal(err.data.message, 'some error');
+            resolve();
+          } else {
+            reject();
+          }
+        });
+      });
+
+      const promisetest = publicClient
+        .request('get', ['some', 'path'])
+        .then(() => assert.fail('should have thrown an error'))
+        .catch(err => {
+          assert.equal(err.message, 'HTTP 400 Error');
+          assert.equal(err.response.statusCode, 400);
+          assert(err.data.message, 'some error');
+        });
+
+      return Promise.all([cbtest, promisetest]);
+    });
+  });
+
   test('.getProductOrderBook()', () => {
     nock(EXCHANGE_API_URL)
       .get('/products/LTC-USD/book?level=3')


### PR DESCRIPTION
## What does it do?

- Fixes error handling expectations as documented in #208
- Non-2xx HTTP status codes will now (correctly) return an error

## Related Issues

- Fixes #208
- Closes #209 (this PR is stacked on top of that one, but this one adds tests and fixes extra edge cases)


  
  