### PR TITLE
Add Websocket#subscribe() and #unsubscribe()

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,7 +474,10 @@ websocket.on('close', () => {
 });
 ```
 
-Optionally set the heartbeat mode or websocket URI.
+The client will automatically subscribe to the 'heartbeat' channel, and
+will subscribe by default to the 'full' channel unless other channels are requested.
+
+To change channel and product subscriptions:
 
 ```javascript
 const websocket = new Gdax.WebsocketClient(
@@ -485,8 +488,12 @@ const websocket = new Gdax.WebsocketClient(
     secret: 'suchsecret',
     passphrase: 'muchpassphrase',
   },
-  { heartbeat: true }
+  { channels: ['full', 'level2'] }
 );
+websocket.unsubscribeChannel('full', 'level2', 'heartbeat');
+websocket.subscribeChannel('ticker', 'matches', 'user');
+websocket.unsubscribeProduct('BTC-USD', 'ETH-USD');
+websocket.subscribeProduct('ETH-BTC', 'ETH-EUR');
 ```
 
 The following events can be emitted from the `WebsocketClient`:

--- a/README.md
+++ b/README.md
@@ -474,10 +474,9 @@ websocket.on('close', () => {
 });
 ```
 
-The client will automatically subscribe to the 'heartbeat' channel, and
-will subscribe by default to the 'full' channel unless other channels are requested.
-
-To change channel and product subscriptions:
+The client will automatically subscribe to the `heartbeat` channel. By
+default, the `full` channel will be subscribed to unless other channels are
+requested.
 
 ```javascript
 const websocket = new Gdax.WebsocketClient(
@@ -490,10 +489,32 @@ const websocket = new Gdax.WebsocketClient(
   },
   { channels: ['full', 'level2'] }
 );
-websocket.unsubscribeChannel('full', 'level2', 'heartbeat');
-websocket.subscribeChannel('ticker', 'matches', 'user');
-websocket.unsubscribeProduct('BTC-USD', 'ETH-USD');
-websocket.subscribeProduct('ETH-BTC', 'ETH-EUR');
+
+```
+
+Optionally, [change subscriptions at runtime](https://docs.gdax.com/#subscribe):
+
+```javascript
+websocket.unsubscribe({ channels: ['full'] });
+
+websocket.subscribe({ product_ids: ['LTC-USD'], channels: ['ticker', 'user'] });
+
+websocket.subscribe({
+  channels: [{
+    name: 'user',
+    product_ids: ['ETH-USD']
+  }]
+});
+
+websocket.unsubscribe({
+  channels: [{
+    name: 'user',
+    product_ids: ['LTC-USD']
+  }, {
+    name: 'user',
+    product_ids: ['ETH-USD']
+  }]
+});
 ```
 
 The following events can be emitted from the `WebsocketClient`:

--- a/lib/clients/websocket.js
+++ b/lib/clients/websocket.js
@@ -17,11 +17,13 @@ class WebsocketClient extends EventEmitter {
     { channels = null } = {}
   ) {
     super();
-    this.productIDs = new Set(Utils.determineProductIDs(productIDs));
+    this.productIDs = Utils.determineProductIDs(productIDs);
     this.websocketURI = websocketURI;
     this.auth = Utils.checkAuth(auth);
-    this.channels = new Set(channels || ['full']);
-    this.channels.add('heartbeat');
+    this.channels = channels || ['full'];
+    if (!this.channels.includes('heartbeat')) {
+      this.channels.push('heartbeat');
+    }
     this.connect();
   }
 
@@ -50,11 +52,11 @@ class WebsocketClient extends EventEmitter {
     const message = { type };
 
     if (channels) {
-      message.channels = [...channels];
+      message.channels = channels;
     }
 
     if (product_ids) {
-      message.product_ids = [...product_ids];
+      message.product_ids = product_ids;
     }
 
     // Add Signature

--- a/lib/clients/websocket.js
+++ b/lib/clients/websocket.js
@@ -46,62 +46,37 @@ class WebsocketClient extends EventEmitter {
     this.socket = null;
   }
 
-  _sendSubscription(
-    type,
-    productIDs = this.productIDs,
-    channels = this.channels
-  ) {
-    const subscribeMessage = {
-      type: type,
-      channels: [...channels],
-    };
+  _sendSubscription(type, { product_ids, channels }) {
+    const message = { type };
 
-    if (productIDs) {
-      subscribeMessage.product_ids = [...productIDs];
+    if (channels) {
+      message.channels = [...channels];
+    }
+
+    if (product_ids) {
+      message.product_ids = [...product_ids];
     }
 
     // Add Signature
     if (this.auth.secret) {
-      let sig = signRequest(this.auth, 'GET', '/users/self/verify');
-      Object.assign(subscribeMessage, sig);
+      const sig = signRequest(this.auth, 'GET', '/users/self/verify');
+      Object.assign(message, sig);
     }
 
-    this.socket.send(JSON.stringify(subscribeMessage));
+    this.socket.send(JSON.stringify(message));
   }
 
-  subscribeProduct(...productIDs) {
-    productIDs.forEach(p => this.productIDs.add(p));
-
-    this._sendSubscription('subscribe');
+  subscribe({ product_ids, channels }) {
+    this._sendSubscription('subscribe', { product_ids, channels });
   }
 
-  subscribeChannel(...channels) {
-    channels.forEach(c => this.channels.add(c));
-
-    this._sendSubscription('subscribe');
-  }
-
-  unsubscribeProduct(...productIDs) {
-    productIDs.forEach(p => this.productIDs.delete(p));
-
-    var channels = [...this.channels].map(c => ({
-      name: c,
-      product_ids: productIDs,
-    }));
-
-    this._sendSubscription('unsubscribe', null, channels);
-  }
-
-  unsubscribeChannel(...channels) {
-    channels.forEach(c => this.channels.delete(c));
-
-    this._sendSubscription('unsubscribe', null, channels);
+  unsubscribe({ product_ids, channels }) {
+    this._sendSubscription('unsubscribe', { product_ids, channels });
   }
 
   onOpen() {
     this.emit('open');
-
-    this._sendSubscription('subscribe');
+    this.subscribe({ product_ids: this.productIDs, channels: this.channels });
   }
 
   onClose() {

--- a/lib/clients/websocket.js
+++ b/lib/clients/websocket.js
@@ -17,13 +17,11 @@ class WebsocketClient extends EventEmitter {
     { channels = null } = {}
   ) {
     super();
-    this.productIDs = Utils.determineProductIDs(productIDs);
+    this.productIDs = new Set(Utils.determineProductIDs(productIDs));
     this.websocketURI = websocketURI;
     this.auth = Utils.checkAuth(auth);
-    this.channels = channels || ['full'];
-    if (!this.channels.includes('heartbeat')) {
-      this.channels.push('heartbeat');
-    }
+    this.channels = new Set(channels || ['full']);
+    this.channels.add('heartbeat');
     this.connect();
   }
 
@@ -48,26 +46,62 @@ class WebsocketClient extends EventEmitter {
     this.socket = null;
   }
 
-  onOpen() {
-    this.emit('open');
-
+  _sendSubscription(
+    type,
+    productIDs = this.productIDs,
+    channels = this.channels
+  ) {
     const subscribeMessage = {
-      type: 'subscribe',
-      product_ids: this.productIDs,
-      channels: this.channels,
+      type: type,
+      channels: [...channels],
     };
+
+    if (productIDs) {
+      subscribeMessage.product_ids = [...productIDs];
+    }
 
     // Add Signature
     if (this.auth.secret) {
-      let sig = signRequest(
-        this.auth,
-        'GET',
-        this.channels ? '/users/self/verify' : '/users/self'
-      );
+      let sig = signRequest(this.auth, 'GET', '/users/self/verify');
       Object.assign(subscribeMessage, sig);
     }
 
     this.socket.send(JSON.stringify(subscribeMessage));
+  }
+
+  subscribeProduct(...productIDs) {
+    productIDs.forEach(p => this.productIDs.add(p));
+
+    this._sendSubscription('subscribe');
+  }
+
+  subscribeChannel(...channels) {
+    channels.forEach(c => this.channels.add(c));
+
+    this._sendSubscription('subscribe');
+  }
+
+  unsubscribeProduct(...productIDs) {
+    productIDs.forEach(p => this.productIDs.delete(p));
+
+    var channels = [...this.channels].map(c => ({
+      name: c,
+      product_ids: productIDs,
+    }));
+
+    this._sendSubscription('unsubscribe', null, channels);
+  }
+
+  unsubscribeChannel(...channels) {
+    channels.forEach(c => this.channels.delete(c));
+
+    this._sendSubscription('unsubscribe', null, channels);
+  }
+
+  onOpen() {
+    this.emit('open');
+
+    this._sendSubscription('subscribe');
   }
 
   onClose() {

--- a/lib/orderbook_sync.js
+++ b/lib/orderbook_sync.js
@@ -31,13 +31,15 @@ class OrderbookSync extends WebsocketClient {
       this._client = new PublicClient(this.apiURI);
     }
 
-    this.productIDs.forEach(productID => {
-      this._queues[productID] = [];
-      this._sequences[productID] = -2;
-      this.books[productID] = new Orderbook();
-    });
+    this.productIDs.forEach(this._newProduct, this);
 
     this.on('message', this.processMessage.bind(this));
+  }
+
+  _newProduct(productID) {
+    this._queues[productID] = [];
+    this._sequences[productID] = -2;
+    this.books[productID] = new Orderbook();
   }
 
   loadOrderbook(productID) {
@@ -67,8 +69,21 @@ class OrderbookSync extends WebsocketClient {
       .catch(problems);
   }
 
+  // subscriptions changed -- possible new products
+  _newSubscription(data) {
+    const channel = data.channels.find(c => c.name === 'full');
+    channel && channel.product_ids
+      .filter(productID => !(productID in this.books))
+      .forEach(productID => this._newProduct(productID));
+  }
+
   processMessage(data) {
-    const { product_id } = data;
+    const { type, product_id } = data;
+
+    if (type === 'subscriptions') {
+      this._newSubscription(data);
+      return;
+    }
 
     if (this._sequences[product_id] < 0) {
       // Orderbook snapshot not loaded yet
@@ -100,7 +115,7 @@ class OrderbookSync extends WebsocketClient {
     this._sequences[product_id] = data.sequence;
     const book = this.books[product_id];
 
-    switch (data.type) {
+    switch (type) {
       case 'open':
         book.add(data);
         break;

--- a/lib/orderbook_sync.js
+++ b/lib/orderbook_sync.js
@@ -74,7 +74,7 @@ class OrderbookSync extends WebsocketClient {
     const channel = data.channels.find(c => c.name === 'full');
     channel && channel.product_ids
       .filter(productID => !(productID in this.books))
-      .forEach(productID => this._newProduct(productID));
+      .forEach(this._newProduct, this);
   }
 
   processMessage(data) {

--- a/tests/websocket.spec.js
+++ b/tests/websocket.spec.js
@@ -101,7 +101,7 @@ suite('WebsocketClient', () => {
 
   test('subscribes to additional products', done => {
     var client;
-    const server = testserver(++port, () => {
+    const server = testserver(port, () => {
       client = new Gdax.WebsocketClient([], 'ws://localhost:' + port);
     });
     server.on('connection', socket => {
@@ -125,7 +125,7 @@ suite('WebsocketClient', () => {
 
   test('unsubscribes from product', done => {
     var client;
-    const server = testserver(++port, () => {
+    const server = testserver(port, () => {
       client = new Gdax.WebsocketClient(['BTC-USD'], 'ws://localhost:' + port);
     });
     server.on('connection', socket => {
@@ -149,7 +149,7 @@ suite('WebsocketClient', () => {
 
   test('subscribes to additional channels', done => {
     var client;
-    const server = testserver(++port, () => {
+    const server = testserver(port, () => {
       client = new Gdax.WebsocketClient(
         ['BTC-USD'],
         'ws://localhost:' + port,
@@ -184,7 +184,7 @@ suite('WebsocketClient', () => {
 
   test('unsubscribes from channel', done => {
     var client;
-    const server = testserver(++port, () => {
+    const server = testserver(port, () => {
       client = new Gdax.WebsocketClient(
         ['BTC-USD'],
         'ws://localhost:' + port,

--- a/tests/websocket.spec.js
+++ b/tests/websocket.spec.js
@@ -100,7 +100,7 @@ suite('WebsocketClient', () => {
   });
 
   test('subscribes to additional products', done => {
-    var client;
+    let client;
     const server = testserver(port, () => {
       client = new Gdax.WebsocketClient([], 'ws://localhost:' + port);
     });
@@ -124,7 +124,7 @@ suite('WebsocketClient', () => {
   });
 
   test('unsubscribes from product', done => {
-    var client;
+    let client;
     const server = testserver(port, () => {
       client = new Gdax.WebsocketClient(['BTC-USD'], 'ws://localhost:' + port);
     });
@@ -148,7 +148,7 @@ suite('WebsocketClient', () => {
   });
 
   test('subscribes to additional channels', done => {
-    var client;
+    let client;
     const server = testserver(port, () => {
       client = new Gdax.WebsocketClient(
         ['BTC-USD'],
@@ -183,7 +183,7 @@ suite('WebsocketClient', () => {
   });
 
   test('unsubscribes from channel', done => {
-    var client;
+    let client;
     const server = testserver(port, () => {
       client = new Gdax.WebsocketClient(
         ['BTC-USD'],

--- a/tests/websocket.spec.js
+++ b/tests/websocket.spec.js
@@ -99,6 +99,119 @@ suite('WebsocketClient', () => {
     });
   });
 
+  test('subscribes to additional products', done => {
+    var client;
+    const server = testserver(++port, () => {
+      client = new Gdax.WebsocketClient([], 'ws://localhost:' + port);
+    });
+    server.on('connection', socket => {
+      socket.once('message', data => {
+        const msg = JSON.parse(data);
+        assert.equal(msg.type, 'subscribe');
+
+        socket.on('message', data => {
+          const msg = JSON.parse(data);
+          assert.equal(msg.type, 'subscribe');
+          assert.ok(msg.product_ids.includes('ETH-BTC'));
+          assert.ok(msg.product_ids.includes('ETH-USD'));
+
+          server.close();
+          done();
+        });
+        client.subscribeProduct('ETH-BTC', 'ETH-USD');
+      });
+    });
+  });
+
+  test('unsubscribes from product', done => {
+    var client;
+    const server = testserver(++port, () => {
+      client = new Gdax.WebsocketClient(['BTC-USD'], 'ws://localhost:' + port);
+    });
+    server.on('connection', socket => {
+      socket.once('message', data => {
+        const msg = JSON.parse(data);
+        assert.equal(msg.type, 'subscribe');
+
+        socket.on('message', data => {
+          const msg = JSON.parse(data);
+          assert.equal(msg.type, 'unsubscribe');
+          assert.deepEqual(msg.channels, [
+            {
+              name: 'full',
+              product_ids: ['BTC-USD'],
+            },
+            {
+              name: 'heartbeat',
+              product_ids: ['BTC-USD'],
+            },
+          ]);
+
+          server.close();
+          done();
+        });
+        client.unsubscribeProduct('BTC-USD');
+      });
+    });
+  });
+
+  test('subscribes to additional channels', done => {
+    var client;
+    const server = testserver(++port, () => {
+      client = new Gdax.WebsocketClient(
+        ['BTC-USD'],
+        'ws://localhost:' + port,
+        null,
+        { channels: ['heartbeat'] }
+      );
+    });
+    server.on('connection', socket => {
+      socket.once('message', data => {
+        const msg = JSON.parse(data);
+        assert.equal(msg.type, 'subscribe');
+
+        socket.on('message', data => {
+          const msg = JSON.parse(data);
+          assert.equal(msg.type, 'subscribe');
+          assert.deepEqual(msg.product_ids, ['BTC-USD']);
+          assert.deepEqual(msg.channels, ['heartbeat', 'ticker', 'user']);
+
+          server.close();
+          done();
+        });
+        client.subscribeChannel('ticker', 'user');
+      });
+    });
+  });
+
+  test('unsubscribes from channel', done => {
+    var client;
+    const server = testserver(++port, () => {
+      client = new Gdax.WebsocketClient(
+        ['BTC-USD'],
+        'ws://localhost:' + port,
+        null,
+        { channels: ['ticker'] }
+      );
+    });
+    server.on('connection', socket => {
+      socket.once('message', data => {
+        const msg = JSON.parse(data);
+        assert.equal(msg.type, 'subscribe');
+
+        socket.on('message', data => {
+          const msg = JSON.parse(data);
+          assert.equal(msg.type, 'unsubscribe');
+          assert.deepEqual(msg.channels, ['ticker']);
+
+          server.close();
+          done();
+        });
+        client.unsubscribeChannel('ticker');
+      });
+    });
+  });
+
   test('passes authentication details through', done => {
     const server = testserver(port, () => {
       new Gdax.WebsocketClient('ETH-USD', 'ws://localhost:' + port, {

--- a/tests/websocket.spec.js
+++ b/tests/websocket.spec.js
@@ -118,7 +118,7 @@ suite('WebsocketClient', () => {
           server.close();
           done();
         });
-        client.subscribeProduct('ETH-BTC', 'ETH-USD');
+        client.subscribe({ product_ids: ['ETH-BTC', 'ETH-USD'] });
       });
     });
   });
@@ -136,21 +136,13 @@ suite('WebsocketClient', () => {
         socket.on('message', data => {
           const msg = JSON.parse(data);
           assert.equal(msg.type, 'unsubscribe');
-          assert.deepEqual(msg.channels, [
-            {
-              name: 'full',
-              product_ids: ['BTC-USD'],
-            },
-            {
-              name: 'heartbeat',
-              product_ids: ['BTC-USD'],
-            },
-          ]);
+          assert.deepEqual(msg.product_ids, ['BTC-USD']);
+          assert.deepEqual(msg.channels, ['full']);
 
           server.close();
           done();
         });
-        client.unsubscribeProduct('BTC-USD');
+        client.unsubscribe({ product_ids: ['BTC-USD'], channels: ['full'] });
       });
     });
   });
@@ -173,13 +165,19 @@ suite('WebsocketClient', () => {
         socket.on('message', data => {
           const msg = JSON.parse(data);
           assert.equal(msg.type, 'subscribe');
-          assert.deepEqual(msg.product_ids, ['BTC-USD']);
-          assert.deepEqual(msg.channels, ['heartbeat', 'ticker', 'user']);
+          assert.deepEqual(msg.channels, [
+            {
+              name: 'ticker',
+              product_ids: ['LTC-USD'],
+            },
+          ]);
 
           server.close();
           done();
         });
-        client.subscribeChannel('ticker', 'user');
+        client.subscribe({
+          channels: [{ name: 'ticker', product_ids: ['LTC-USD'] }],
+        });
       });
     });
   });
@@ -207,7 +205,7 @@ suite('WebsocketClient', () => {
           server.close();
           done();
         });
-        client.unsubscribeChannel('ticker');
+        client.unsubscribe({ channels: ['ticker'] });
       });
     });
   });


### PR DESCRIPTION
## What does it do?

- This PR is stacked on top of @fuzzyTew's PR #179.
- Instead of a stateful `Websocket#[un]subscribeProduct()` and `#[un]subscribeChannel()`, the changes here simplify the method signatures down to just a stateless `#subscribe()` and `#unsubscribe()` that is a direct pass through to the GDAX API.
- These new method signatures match the [GDAX API `subscribe`/`unsubscribe` messages](https://docs.gdax.com/#subscribe) directly.

## Related Issues

- Closes #179 

## Example Usage:

```javascript
websocket.unsubscribe({ channels: ['full'] });

websocket.subscribe({ product_ids: ['LTC-USD'], channels: ['ticker', 'user'] });

websocket.subscribe({
  channels: [{
    name: 'user',
    product_ids: ['ETH-USD']
  }]
});

websocket.unsubscribe({
  channels: [{
    name: 'user',
    product_ids: ['LTC-USD']
  }, {
    name: 'user',
    product_ids: ['ETH-USD']
  }]
});
```
