### PR TITLE
Emit error when websocket message is an error

### DIFF
--- a/lib/clients/websocket.js
+++ b/lib/clients/websocket.js
@@ -76,7 +76,12 @@ class WebsocketClient extends EventEmitter {
   }
 
   onMessage(data) {
-    this.emit('message', JSON.parse(data));
+    const message = JSON.parse(data);
+    if (message.type === 'error') {
+      this.onError(message);
+    } else {
+      this.emit('message', message);
+    }
   }
 
   onError(err) {

--- a/tests/orderbook_sync.spec.js
+++ b/tests/orderbook_sync.spec.js
@@ -10,7 +10,7 @@ const EXCHANGE_API_URL = 'https://api.gdax.com';
 
 suite('OrderbookSync', () => {
   test('not passes authentication details to websocket', done => {
-    const server = testserver(++port, () => {
+    const server = testserver(port, () => {
       new Gdax.OrderbookSync(
         'BTC-USD',
         EXCHANGE_API_URL,
@@ -32,7 +32,7 @@ suite('OrderbookSync', () => {
   });
 
   test('passes authentication details to websocket', done => {
-    const server = testserver(++port, () => {
+    const server = testserver(port, () => {
       new Gdax.OrderbookSync(
         'BTC-USD',
         EXCHANGE_API_URL,
@@ -55,7 +55,7 @@ suite('OrderbookSync', () => {
   });
 
   test('passes authentication details to websocket (via AuthenticationClient for backwards compatibility)', done => {
-    const server = testserver(++port, () => {
+    const server = testserver(port, () => {
       new Gdax.OrderbookSync(
         'BTC-USD',
         EXCHANGE_API_URL,
@@ -86,7 +86,7 @@ suite('OrderbookSync', () => {
         bids: [],
       });
 
-    const server = testserver(++port, () => {
+    const server = testserver(port, () => {
       const orderbookSync = new Gdax.OrderbookSync(
         'BTC-USD',
         EXCHANGE_API_URL,
@@ -116,7 +116,7 @@ suite('OrderbookSync', () => {
         bids: [],
       });
 
-    const server = testserver(++port, () => {
+    const server = testserver(port, () => {
       const orderbookSync = new Gdax.OrderbookSync(
         'BTC-USD',
         EXCHANGE_API_URL,
@@ -143,7 +143,7 @@ suite('OrderbookSync', () => {
       .get('/products/BTC-USD/book?level=3')
       .replyWithError('whoops');
 
-    const server = testserver(++port, () => {
+    const server = testserver(port, () => {
       const orderbookSync = new Gdax.OrderbookSync(
         'BTC-USD',
         EXCHANGE_API_URL,
@@ -169,7 +169,7 @@ suite('OrderbookSync', () => {
       .get('/products/BTC-USD/book?level=3')
       .replyWithError('whoops');
 
-    const server = testserver(++port, () => {
+    const server = testserver(port, () => {
       const orderbookSync = new Gdax.OrderbookSync(
         'BTC-USD',
         EXCHANGE_API_URL,
@@ -208,7 +208,7 @@ suite('OrderbookSync', () => {
         bids: [],
       });
 
-    const server = testserver(++port, () => {
+    const server = testserver(port, () => {
       const orderbookSync = new Gdax.OrderbookSync(
         ['BTC-USD', 'ETH-USD'],
         EXCHANGE_API_URL,

--- a/tests/websocket.spec.js
+++ b/tests/websocket.spec.js
@@ -6,7 +6,7 @@ let port = 56632;
 
 suite('WebsocketClient', () => {
   test('connects to specified server', done => {
-    const server = testserver(++port, () => {
+    const server = testserver(port, () => {
       const websocketClient = new Gdax.WebsocketClient(
         ['BTC-EUR'],
         'ws://localhost:' + port
@@ -19,7 +19,7 @@ suite('WebsocketClient', () => {
   });
 
   test('subscribes to the default product (BTC-USD) and default channel (full) if undefined', done => {
-    const server = testserver(++port, () => {
+    const server = testserver(port, () => {
       new Gdax.WebsocketClient(null, 'ws://localhost:' + port);
     });
     server.on('connection', socket => {
@@ -36,7 +36,7 @@ suite('WebsocketClient', () => {
   });
 
   test('subscribes to the default product (BTC-USD) if empty string', done => {
-    const server = testserver(++port, () => {
+    const server = testserver(port, () => {
       new Gdax.WebsocketClient('', 'ws://localhost:' + port);
     });
     server.on('connection', socket => {
@@ -52,7 +52,7 @@ suite('WebsocketClient', () => {
   });
 
   test('subscribes to the default product (BTC-USD) if empty array passed', done => {
-    const server = testserver(++port, () => {
+    const server = testserver(port, () => {
       new Gdax.WebsocketClient([], 'ws://localhost:' + port);
     });
     server.on('connection', socket => {
@@ -68,7 +68,7 @@ suite('WebsocketClient', () => {
   });
 
   test('subscribes to the specified products', done => {
-    const server = testserver(++port, () => {
+    const server = testserver(port, () => {
       new Gdax.WebsocketClient(['BTC-EUR'], 'ws://localhost:' + port);
     });
     server.on('connection', socket => {
@@ -84,7 +84,7 @@ suite('WebsocketClient', () => {
   });
 
   test('subscribes to the specified product (backward compatibility)', done => {
-    const server = testserver(++port, () => {
+    const server = testserver(port, () => {
       new Gdax.WebsocketClient('ETH-USD', 'ws://localhost:' + port);
     });
     server.on('connection', socket => {
@@ -100,7 +100,7 @@ suite('WebsocketClient', () => {
   });
 
   test('passes authentication details through', done => {
-    const server = testserver(++port, () => {
+    const server = testserver(port, () => {
       new Gdax.WebsocketClient('ETH-USD', 'ws://localhost:' + port, {
         key: 'suchkey',
         secret: 'suchsecret',
@@ -123,7 +123,7 @@ suite('WebsocketClient', () => {
   });
 
   test('passes channels through with heartbeat added', done => {
-    const server = testserver(++port, () => {
+    const server = testserver(port, () => {
       new Gdax.WebsocketClient(
         'ETH-USD',
         'ws://localhost:' + port,
@@ -151,7 +151,7 @@ suite('WebsocketClient', () => {
   });
 
   test('emits errors when receiving an error message', done => {
-    const server = testserver(++port, () => {
+    const server = testserver(port, () => {
       const client = new Gdax.WebsocketClient(null, 'ws://localhost:' + port);
 
       client.once('error', err => {

--- a/tests/websocket.spec.js
+++ b/tests/websocket.spec.js
@@ -149,4 +149,26 @@ suite('WebsocketClient', () => {
       });
     });
   });
+
+  test('emits errors when receiving an error message', done => {
+    const server = testserver(++port, () => {
+      const client = new Gdax.WebsocketClient(null, 'ws://localhost:' + port);
+
+      client.once('error', err => {
+        assert.equal(err.message, 'test error');
+        assert.equal(err.reason, 'because error');
+        done();
+      });
+    });
+
+    server.once('connection', socket => {
+      socket.send(
+        JSON.stringify({
+          type: 'error',
+          message: 'test error',
+          reason: 'because error',
+        })
+      );
+    });
+  });
 });


### PR DESCRIPTION
## What does it do?

Before, if an `error` message is sent from the server, that error is emitted as regular `message` data. Now, if a message of `type=error` arrives, it is emitted as an `error` instead.

## What else?

Also removes auto-incrementing port for testing websocket server connections. We got to a point where we ran into port conflicts on the CI server.

## Related Issues

- FIxes #219

/cc @fb55 