### PR TITLE
Ignore some files when publishing the package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,9 @@
+*.swp
+
+/.idea
+/package-lock.json
+/yarn.lock
+/.node-version
+
 circle.yml
-tests/
+/tests


### PR DESCRIPTION
No need to include the CI config and `tests` folder in the published npm package 😘