### PR TITLE
Remove github install instructions from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,7 @@ The official Node.js library for Coinbase's [GDAX API](https://docs.gdax.com/).
 ## Installation
 
 ```bash
-# from npm
 npm install gdax
-
-# from GitHub
-npm install coinbase/gdax-node
 ```
 
 You can learn about the API responses of each endpoint [by reading our


### PR DESCRIPTION
Otherwise the master branch always has to be spotless. 