### PR TITLE
Improve error handling by checking auth before every signature

### DIFF
--- a/lib/request_signer.js
+++ b/lib/request_signer.js
@@ -1,6 +1,8 @@
 'use strict';
 const crypto = require('crypto');
 const querystring = require('querystring');
+const Utils = require('./utilities.js');
+
 /**
  Signs request messages for authenticated requests to GDAX
  * @param auth {object} hash containing key, secret and passphrase
@@ -12,6 +14,7 @@ const querystring = require('querystring');
  * @returns {{key: string, signature: *, timestamp: number, passphrase: string}}
  */
 module.exports.signRequest = (auth, method, path, options = {}) => {
+  Utils.checkAuth(auth);
   const timestamp = Date.now() / 1000;
   let body = '';
   if (options.body) {

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -13,9 +13,9 @@ function determineProductIDs(productIDs) {
 }
 
 function checkAuth(auth) {
-  if (auth && !(auth.secret && auth.key && auth.passphrase)) {
+  if (auth && !(auth.key && auth.secret && auth.passphrase)) {
     throw new Error(
-      'Invalid or incomplete authentication credentials. You should either provide all of the secret, key and passphrase fields, or leave auth null'
+      'Invalid or incomplete authentication credentials. Please provide all of the key, secret, and passphrase fields.'
     );
   }
   return auth || {};


### PR DESCRIPTION
Results in the following error if credentials are missing before signing a request:

```
Error: Invalid or incomplete authentication credentials. Please provide all of the key, secret, and passphrase fields.
```

Closes #232

/cc @fb55 
