### PR TITLE
Fix UnhandledPromiseRejectionWarning in OrderbookSync

### DIFF
--- a/lib/orderbook_sync.js
+++ b/lib/orderbook_sync.js
@@ -36,26 +36,8 @@ class OrderbookSync extends WebsocketClient {
       this._sequences[productID] = -2;
       this.books[productID] = new Orderbook();
     });
-  }
 
-  onMessage(data) {
-    data = JSON.parse(data);
-    this.emit('message', data);
-
-    const { product_id } = data;
-
-    if (this._sequences[product_id] < 0) {
-      // Orderbook snapshot not loaded yet
-      this._queues[product_id].push(data);
-
-      if (this._sequences[product_id] === -2) {
-        // Start first resync
-        this._sequences[product_id] = -1;
-        this.loadOrderbook(product_id);
-      }
-    } else {
-      this.processMessage(data);
-    }
+    this.on('message', this.processMessage.bind(this));
   }
 
   loadOrderbook(productID) {
@@ -63,32 +45,47 @@ class OrderbookSync extends WebsocketClient {
       return;
     }
 
-    this._client
-      .getProductOrderBook(productID, { level: 3 })
-      .then(onData.bind(this))
-      .catch(onError.bind(this));
+    this._queues[productID] = [];
+    this._sequences[productID] = -1;
 
-    function onData(data) {
+    const process = data => {
       this.books[productID].state(data);
 
       this._sequences[productID] = data.sequence;
-      this._queues[productID].forEach(this.processMessage.bind(this));
+      this._queues[productID].forEach(this.processMessage, this);
       this._queues[productID] = [];
-    }
+    };
 
-    function onError(err) {
-      err = err ? (err.message ? err.message : err) : '';
+    const problems = err => {
+      err = err && (err.message || err);
       this.emit('error', new Error('Failed to load orderbook: ' + err));
-    }
+    };
+
+    this._client
+      .getProductOrderBook(productID, { level: 3 })
+      .then(process)
+      .catch(problems);
   }
 
   processMessage(data) {
     const { product_id } = data;
 
+    if (this._sequences[product_id] < 0) {
+      // Orderbook snapshot not loaded yet
+      this._queues[product_id].push(data);
+    }
+
+    if (this._sequences[product_id] === -2) {
+      // Start first sync
+      this.loadOrderbook(product_id);
+      return;
+    }
+
     if (this._sequences[product_id] === -1) {
       // Resync is in process
       return;
     }
+
     if (data.sequence <= this._sequences[product_id]) {
       // Skip this one, since it was already processed
       return;
@@ -96,9 +93,6 @@ class OrderbookSync extends WebsocketClient {
 
     if (data.sequence !== this._sequences[product_id] + 1) {
       // Dropped a message, start a resync process
-      this._queues[product_id] = [];
-      this._sequences[product_id] = -1;
-
       this.loadOrderbook(product_id);
       return;
     }

--- a/tests/orderbook_sync.spec.js
+++ b/tests/orderbook_sync.spec.js
@@ -150,17 +150,15 @@ suite('OrderbookSync', () => {
         'ws://localhost:' + port
       );
 
-      orderbookSync.on('message', () =>
-        assert.fail('should not have emitted message')
-      );
-      orderbookSync.on('error', err =>
-        assert.equal(err.message, 'Failed to load orderbook: whoops')
-      );
+      orderbookSync.on('error', err => {
+        assert.equal(err.message, 'Failed to load orderbook: whoops');
+        server.close();
+        done();
+      });
     });
 
-    server.on('connection', () => {
-      server.close();
-      done();
+    server.on('connection', socket => {
+      socket.send(JSON.stringify({ product_id: 'BTC-USD' }));
     });
   });
 
@@ -177,17 +175,15 @@ suite('OrderbookSync', () => {
         { key: 'key', secret: 'secret', passphrase: 'pass' }
       );
 
-      orderbookSync.on('message', () =>
-        assert.fail('should not have emitted message')
-      );
-      orderbookSync.on('error', err =>
-        assert.equal(err.message, 'Failed to load orderbook: whoops')
-      );
+      orderbookSync.on('error', err => {
+        assert.equal(err.message, 'Failed to load orderbook: whoops');
+        server.close();
+        done();
+      });
     });
 
-    server.on('connection', () => {
-      server.close();
-      done();
+    server.on('connection', socket => {
+      socket.send(JSON.stringify({ product_id: 'BTC-USD' }));
     });
   });
 


### PR DESCRIPTION
I got tired of seeing the following warning in the test suite:

```
(node:59176) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 3): Error: Failed to load orderbook: whoops
```

Turned out that simplifying the code behind grabbing the initial Orderbook did the trick.

I think this fixes #233 

/cc @fb55 
