### PR TITLE
Fix precommit: eslint cannot be run on json or markdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,10 +65,7 @@
     "precommit": "lint-staged"
   },
   "lint-staged": {
-    "*.{js,json,md}": [
-      "eslint --fix",
-      "prettier --write",
-      "git add"
-    ]
+    "*.{js}": ["eslint --fix", "prettier --write", "git add"],
+    "*.{json,md}": ["prettier --write", "git add"]
   }
 }


### PR DESCRIPTION
Fixes mistake in `precommit` setup. `eslint` cannot be run on json or markdown.

Ref #235

/cc @fb55 