### PR TITLE
Upgrade and relax dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "eslint": "^4.0.0",
     "husky": "^0.13.4",
     "lint-staged": "^3.6.1",
-    "mocha": "3.4.2",
-    "nock": "9.0.13",
+    "mocha": "^5.0.0",
+    "nock": "^9.0.13",
     "prettier": "^1.9.2"
   },
   "directories": {

--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
     }
   ],
   "dependencies": {
-    "bintrees": "1.0.1",
-    "num": "0.3.0",
-    "request": "2.81.0",
-    "ws": "3.0.0"
+    "bintrees": "^1.0.1",
+    "num": "^0.3.0",
+    "request": "^2.81.0",
+    "ws": "^4.0.0"
   },
   "description": "Client for the GDAX API",
   "devDependencies": {

--- a/tests/websocket.spec.js
+++ b/tests/websocket.spec.js
@@ -144,6 +144,7 @@ suite('WebsocketClient', () => {
         assert.deepEqual(msg.channels, ['user', 'ticker', 'heartbeat']);
         assert(msg.timestamp);
         assert(msg.signature);
+
         server.close();
         done();
       });
@@ -157,6 +158,8 @@ suite('WebsocketClient', () => {
       client.once('error', err => {
         assert.equal(err.message, 'test error');
         assert.equal(err.reason, 'because error');
+
+        server.close();
         done();
       });
     });


### PR DESCRIPTION
## What does it do?

- Upgrades and relaxes core dependencies. Static versions are ill-advised for shared libraries, because clients cannot take advantage of 3rd party bug fixes and performance improvements. Let semver do its thing.
- Upgrades mocha and nock dev dependencies. This actually exposed an errant test connection in test suite.
- Closes out the errant websocket server in test suite.

/cc @fb55 

Aside, much of ~#239~ (now merged) and ~#240~ (now merged) was discovered while trying to work on this.