### PR TITLE
Add clockSkew parameter to account for skew between GDAX time and local machine time

### DIFF
--- a/lib/clients/authenticated.js
+++ b/lib/clients/authenticated.js
@@ -8,12 +8,18 @@ class AuthenticatedClient extends PublicClient {
     this.key = key;
     this.secret = secret;
     this.passphrase = passphrase;
+    if (options.offset > 0) {
+      this.offset = options.offset;
+    }
   }
 
   request(method, uriParts, opts = {}, callback) {
     if (!callback && typeof opts === 'function') {
       callback = opts;
       opts = {};
+    }
+    if (this.offset) {
+      opts.offset = this.offset;
     }
 
     this.addHeaders(

--- a/lib/clients/authenticated.js
+++ b/lib/clients/authenticated.js
@@ -8,7 +8,7 @@ class AuthenticatedClient extends PublicClient {
     this.key = key;
     this.secret = secret;
     this.passphrase = passphrase;
-    if (options.offset > 0) {
+    if (options.offset) {
       this.offset = options.offset;
     }
   }

--- a/lib/clients/authenticated.js
+++ b/lib/clients/authenticated.js
@@ -8,8 +8,8 @@ class AuthenticatedClient extends PublicClient {
     this.key = key;
     this.secret = secret;
     this.passphrase = passphrase;
-    if (options.offset) {
-      this.offset = options.offset;
+    if (options.clockSkew) {
+      this.clockSkew = options.clockSkew;
     }
   }
 
@@ -18,8 +18,8 @@ class AuthenticatedClient extends PublicClient {
       callback = opts;
       opts = {};
     }
-    if (this.offset) {
-      opts.offset = this.offset;
+    if (this.clockSkew) {
+      opts.clockSkew = this.clockSkew;
     }
 
     this.addHeaders(

--- a/lib/request_signer.js
+++ b/lib/request_signer.js
@@ -11,12 +11,12 @@ const Utils = require('./utilities.js');
  * @param options {object} An optional object containing one of
  * @param options.body {object} A hash of body properties
  * @param options.qs {object} A hash of query string parameters
- * @param options.offset {float} Number of seconds local machine's clock is ahead of GDAX
+ * @param options.clockSkew {float} Number of seconds GDAX's time is ahead of local machine's
  * @returns {{key: string, signature: *, timestamp: number, passphrase: string}}
  */
 module.exports.signRequest = (auth, method, path, options = {}) => {
   Utils.checkAuth(auth);
-  const timestamp = Date.now() / 1000 + (options.offset ? options.offset : 0);
+  const timestamp = Date.now() / 1000 + (options.clockSkew ? options.clockSkew : 0);
   let body = '';
   if (options.body) {
     body = JSON.stringify(options.body);

--- a/lib/request_signer.js
+++ b/lib/request_signer.js
@@ -2,6 +2,7 @@
 const crypto = require('crypto');
 const querystring = require('querystring');
 const Utils = require('./utilities.js');
+const request = require('request');
 
 /**
  Signs request messages for authenticated requests to GDAX
@@ -11,11 +12,12 @@ const Utils = require('./utilities.js');
  * @param options {object} An optional object containing one of
  * @param options.body {object} A hash of body properties
  * @param options.qs {object} A hash of query string parameters
+ * @param options.offset {float} Number of seconds local machine's clock is ahead of GDAX
  * @returns {{key: string, signature: *, timestamp: number, passphrase: string}}
  */
 module.exports.signRequest = (auth, method, path, options = {}) => {
   Utils.checkAuth(auth);
-  const timestamp = Date.now() / 1000;
+  const timestamp = Date.now() / 1000 + (options.offset ? options.offset : 0);
   let body = '';
   if (options.body) {
     body = JSON.stringify(options.body);

--- a/lib/request_signer.js
+++ b/lib/request_signer.js
@@ -2,7 +2,6 @@
 const crypto = require('crypto');
 const querystring = require('querystring');
 const Utils = require('./utilities.js');
-const request = require('request');
 
 /**
  Signs request messages for authenticated requests to GDAX


### PR DESCRIPTION
## Scenario
If a user's local machine's time is skewed with respect to GDAX API, the API calls fail with error response `{ message: 'request timestamp expired' }`. A solution is for the user to adjust their machine's time. But if a user is unwilling to do that, s/he should have a way to configure the authenticated client to account for the clock skew.

## Change summary
This commit adds support for a `clockSkew` field in options parameter of the AuthenticatedClient constructor whose value should be set to the difference of time between GDAX API server (can be found as epoch field at https://api.gdax.com/time) and local machine's time (found using Date.now() in Node or browser).