### PR TITLE
Switch to Travis CI build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+sudo: false
+language: node_js
+node_js:
+  - "6"
+  - "8"
+  - "9"
+script:
+  - npm run lint
+  - npm run prettier
+  - npm test
+matrix:
+  fast_finish: true
+  allow_failures:
+    - node_js: "9"

--- a/README.md
+++ b/README.md
@@ -489,7 +489,6 @@ const websocket = new Gdax.WebsocketClient(
   },
   { channels: ['full', 'level2'] }
 );
-
 ```
 
 Optionally, [change subscriptions at runtime](https://docs.gdax.com/#subscribe):
@@ -500,20 +499,25 @@ websocket.unsubscribe({ channels: ['full'] });
 websocket.subscribe({ product_ids: ['LTC-USD'], channels: ['ticker', 'user'] });
 
 websocket.subscribe({
-  channels: [{
-    name: 'user',
-    product_ids: ['ETH-USD']
-  }]
+  channels: [
+    {
+      name: 'user',
+      product_ids: ['ETH-USD'],
+    },
+  ],
 });
 
 websocket.unsubscribe({
-  channels: [{
-    name: 'user',
-    product_ids: ['LTC-USD']
-  }, {
-    name: 'user',
-    product_ids: ['ETH-USD']
-  }]
+  channels: [
+    {
+      name: 'user',
+      product_ids: ['LTC-USD'],
+    },
+    {
+      name: 'user',
+      product_ids: ['ETH-USD'],
+    },
+  ],
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# GDAX [![CircleCI](https://circleci.com/gh/coinbase/gdax-node.svg?style=svg)](https://circleci.com/gh/coinbase/gdax-node) [![npm version](https://badge.fury.io/js/gdax.svg)](https://badge.fury.io/js/gdax)
+# GDAX [![Build Status](https://travis-ci.org/coinbase/gdax-node.svg?branch=master)](https://travis-ci.org/coinbase/gdax-node) [![npm version](https://badge.fury.io/js/gdax.svg)](https://badge.fury.io/js/gdax)
 
 The official Node.js library for Coinbase's [GDAX API](https://docs.gdax.com/).
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,0 @@
-machine:
-  node:
-    version: 6.12.2

--- a/lib/orderbook_sync.js
+++ b/lib/orderbook_sync.js
@@ -72,9 +72,10 @@ class OrderbookSync extends WebsocketClient {
   // subscriptions changed -- possible new products
   _newSubscription(data) {
     const channel = data.channels.find(c => c.name === 'full');
-    channel && channel.product_ids
-      .filter(productID => !(productID in this.books))
-      .forEach(this._newProduct, this);
+    channel &&
+      channel.product_ids
+        .filter(productID => !(productID in this.books))
+        .forEach(this._newProduct, this);
   }
 
   processMessage(data) {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,9 @@
     "url": "git://github.com/coinbase/gdax-node.git"
   },
   "scripts": {
+    "lint": "eslint --ext .js ./",
+    "prettier": "prettier -l README.md *.js **/*.js",
+    "prettier-write": "npm run prettier -- --write",
     "test": "mocha --full-trace --ui tdd --bail --reporter spec tests/*.js",
     "precommit": "lint-staged"
   },


### PR DESCRIPTION
## What does it do?

- Adds Travis CI build matrix (with node v6, v8, v9)
- Removes Circle Ci build
- Replaces build badge in README
- Also runs a `lint` and `prettier` sanity test prior to running the standard test suite (for people who might disable the `precommit` hooks while using `lint-staged`).

## What else?

- `prettier` is only run against `*.js` files, because different npm versions mess with package.json & package-lock.json differently (causing the build to unnecessarily fail on different versions).
- **This is going to require someone at Coinbase to enable Travis builds against this repository.**
- Removal of Circle CI was purposefully placed on its own commit. If Coinbase still uses the Circle CI build output internally (as part of a larger status board), let me know, and I'll revert that one commit.

- **The Circle CI check that's (currently) part of this repository is going to fail, because the config was removed, and Circle CI defaults to Node v4**

## Related Issues

- Closes #249

## Screenshots

<img width="1158" alt="gdax-node - travis ci 2018-01-24 10-38-12" src="https://user-images.githubusercontent.com/740/35347549-b2199972-00f2-11e8-952f-3b39ed35a94a.png">

/cc @fb55 
