### PR TITLE
corrected README.md Websocket Client example to use wss endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,7 +491,7 @@ requested.
 ```javascript
 const websocket = new Gdax.WebsocketClient(
   ['BTC-USD', 'ETH-USD'],
-  'https://api-public.sandbox.gdax.com',
+  'wss://ws-feed-public.sandbox.gdax.com',
   {
     key: 'suchkey',
     secret: 'suchsecret',


### PR DESCRIPTION
Websocket Client example call should use a wss endpoint, not the rest endpoint. 