### PR TITLE
Check for null price on change request

### DIFF
--- a/lib/orderbook.js
+++ b/lib/orderbook.js
@@ -17,18 +17,18 @@ class Orderbook {
     if (book) {
       book.bids
         .forEach(order => this.add({
-           id: order[2],
-           side: 'buy',
-           price: BigNumber(order[0]),
-           size: BigNumber(order[1]),
+          id: order[2],
+          side: 'buy',
+          price: BigNumber(order[0]),
+          size: BigNumber(order[1]),
         }));
 
       book.asks
         .forEach(order => this.add({
-           id: order[2],
-           side: 'sell',
-           price: BigNumber(order[0]),
-           size: BigNumber(order[1]),
+          id: order[2],
+          side: 'sell',
+          price: BigNumber(order[0]),
+          size: BigNumber(order[1]),
         }));
     } else {
       book = { asks: [], bids: [] };
@@ -110,6 +110,11 @@ class Orderbook {
   }
 
   change(change) {
+    // price of null indicates market order
+    if (change.price === null || change.price === undefined) {
+      return;
+    }
+
     const size = BigNumber(change.new_size);
     const price = BigNumber(change.price);
     const order = this.get(change.order_id);

--- a/tests/orderbook.spec.js
+++ b/tests/orderbook.spec.js
@@ -204,4 +204,34 @@ suite('Orderbook', () => {
 
     checkState(orderbook.state(), expectedState);
   });
+
+  test('.change() market order', () => {
+    const apiState = {
+      bids: [[200, 10, 'super-duper-id']],
+      asks: [],
+    };
+
+    const change = {
+      order_id: 'super-duper-id-2',
+      side: 'buy',
+    };
+
+    const expectedState = {
+      bids: [
+        {
+          id: 'super-duper-id',
+          side: 'buy',
+          price: 200,
+          size: 10,
+        },
+      ],
+      asks: [],
+    };
+
+    const orderbook = new Gdax.Orderbook();
+    orderbook.state(apiState);
+    orderbook.change(change);
+
+    checkState(orderbook.state(), expectedState);
+  });
 });


### PR DESCRIPTION
Fixes #255.  A null price can be returned from the API on a change request, when this happens in indicates that the order was a market order.  The problem currently is that there is no check to ensure that the price is not null, and passing a null price to BigNumber will cause an uncaught exception.

> Any change message where the price is null indicates that the change message is for a market order. Change messages for limit orders will always have a price specified.

[Relevant GDAX API docs](https://docs.gdax.com/#the-code-classprettyprintfullcode-channel)