### PR TITLE
Fix BaseOrderInfo's type definition by adding 'rejected' to the union…

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -59,7 +59,7 @@ declare module 'gdax' {
         post_only: boolean;
         fill_fees: string;
         filled_size: string;
-        status: 'received' | 'open' | 'done' | 'pending';
+        status: 'rejected' | 'received' | 'open' | 'done' | 'pending';
         settled: boolean;
         executed_value: string;
     }


### PR DESCRIPTION
… of valid statuses

🙂