### PR TITLE
Arg count fix in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ async function yourFunction() {
 
 ### Using Callbacks
 
-Your callback should accept two arguments:
+Your callback should accept three arguments:
 
 - `error`: contains an error message (`string`), or `null` if no was error
   encountered


### PR DESCRIPTION
"Your callback should accept **two** arguments:" but then three are listed.  This addresses the inconsistency.