### PR TITLE
Add typings for stop limit orders

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,6 +17,8 @@ declare module 'gdax' {
         product_id: string;
         client_oid?: string;
         stp?: 'dc' | 'co' | 'cn' | 'cb';
+        stop?: 'loss' | 'entry';
+        stop_price?: string;
     }
 
     interface LimitOrder extends BaseOrder {


### PR DESCRIPTION
The ability to place stop limit orders is not documented as described in issue #164. While it's still possible to place a stop limit when directly interfacing with the gdax-node library it is not possible when using the gdax-tt due to the typescript declaration limitations. I am extending the BaseOrder interface declaration as per the [GDAX API Reference](https://docs.gdax.com/#place-a-new-order). This will enable the necessary changes to be made on the gdax-tt project to also support stop limit orders. 