### PR TITLE
When a request fails, always set the data property.

### DIFF
--- a/lib/clients/public.js
+++ b/lib/clients/public.js
@@ -63,6 +63,7 @@ class PublicClient {
 
       if (err) {
         err.response = response;
+        err.data = data;
       } else if (response.statusCode > 299) {
         err = new Error(
           `HTTP ${response.statusCode} Error: ${data && data.message}`
@@ -72,6 +73,7 @@ class PublicClient {
       } else if (data === null) {
         err = new Error('Response could not be parsed as JSON');
         err.response = response;
+        err.data = data;
       }
 
       if (typeof callback === 'function') {


### PR DESCRIPTION
This is for consistency between the different ways an Error instance
is created and populated.