### PR TITLE
Fix cancelAllOrders compile error.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -224,8 +224,8 @@ declare module 'gdax' {
         cancelOrder(orderID: string, callback: callback<string[]>): void;
         cancelOrder(orderID: string): Promise<string[]>;
 
-        cancelAllOrders(args?: { product_id: string }, callback: callback<string[]>): void;
-        cancelAllOrders(args?: { product_id: string }): Promise<string[]>;
+        cancelAllOrders(args: { product_id?: string }, callback: callback<string[]>): void;
+        cancelAllOrders(args: { product_id?: string }): Promise<string[]>;
 
         getOrders(callback: callback<OrderInfo[]>): void;
         getOrders(): Promise<OrderInfo[]>;


### PR DESCRIPTION
Make the args argument required, but make its product_id property
optional, so it's still easy to not set it.

index.d.ts(225,56): error TS1016: A required parameter cannot follow an optional parameter.