### PR TITLE
Add depositPayment method to support /deposits/payment-method

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,18 @@ const withdrawAddressParams = {
 authedClient.withdrawCrypto(withdrawAddressParams, callback);
 ```
 
+* [`depositPayment`](https://docs.gdax.com/#payment-method)
+
+```js
+// Schedule Deposit to your Exchange USD account from a configured payment method.
+const depositPaymentParamsUSD = {
+  amount: '100.00',
+  currency: 'USD',
+  payment_method_id: 'bc6d7162-d984-5ffa-963c-a493b1c1370b', // ach_bank_account
+};
+authedClient.depositPayment(depositPaymentParamsUSD, callback);
+```
+
 * [`getTrailingVolume`](https://docs.gdax.com/#user-account)
 
 ```js

--- a/lib/clients/authenticated.js
+++ b/lib/clients/authenticated.js
@@ -183,7 +183,7 @@ class AuthenticatedClient extends PublicClient {
     }.call(this);
 
     if (callback) {
-      p.catch(() => { });
+      p.catch(() => {});
       return undefined;
     } else {
       return p;

--- a/lib/clients/authenticated.js
+++ b/lib/clients/authenticated.js
@@ -183,7 +183,7 @@ class AuthenticatedClient extends PublicClient {
     }.call(this);
 
     if (callback) {
-      p.catch(() => {});
+      p.catch(() => { });
       return undefined;
     } else {
       return p;
@@ -248,6 +248,12 @@ class AuthenticatedClient extends PublicClient {
     this._requireParams(params, ['amount', 'currency', 'coinbase_account_id']);
     return this.post(['deposits/coinbase-account'], { body: params }, callback);
   }
+
+  depositPayment(params, callback) {
+    this._requireParams(params, ['amount', 'currency', 'payment_method_id']);
+    return this.post(['deposits/payment-method'], { body: params }, callback);
+  }
+
 
   depositCrypto(params, callback) {
     this._requireParams(params, ['currency']);

--- a/tests/authenticated.spec.js
+++ b/tests/authenticated.spec.js
@@ -175,7 +175,7 @@ suite('AuthenticatedClient', () => {
       .then(() => done())
       .catch(err => assert.ifError(err) || assert.fail());
   });
-  
+
   test('.getAccountTransfers()', done => {
     const expectedResponse = [
       {
@@ -479,7 +479,7 @@ suite('AuthenticatedClient', () => {
             assert(err);
             resolve();
           })
-          .catch(() => {});
+          .catch(() => { });
       });
 
       let promisetest = authClient
@@ -733,6 +733,36 @@ suite('AuthenticatedClient', () => {
     });
 
     let promisetest = authClient.deposit(transfer);
+
+    Promise.all([cbtest, promisetest])
+      .then(() => done())
+      .catch(err => assert.ifError(err) || assert.fail);
+  });
+
+  test('.depositPayment()', done => {
+    const transfer = {
+      amount: 10480,
+      currency: 'USD',
+      payment_method_id: 'test-id',
+    };
+
+    const expectedTransfer = transfer;
+
+    nock(EXCHANGE_API_URL)
+      .post('/deposits/payment-method', expectedTransfer)
+      .times(2)
+      .reply(200, {});
+
+    let cbtest = new Promise((resolve, reject) => {
+      authClient.depositPayment(transfer, err => {
+        if (err) {
+          reject(err);
+        }
+        resolve();
+      });
+    });
+
+    let promisetest = authClient.depositPayment(transfer);
 
     Promise.all([cbtest, promisetest])
       .then(() => done())


### PR DESCRIPTION
The current authenticated client does not support depositing funds from a payment method.  

The deposit command wraps the /deposits/coinbase-account for moving funds between coinbase accounts. In order to initiate a transfer a call to /deposits/coinbase-account is needed. 