### PR TITLE
CircleCI Build Matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,36 @@
+version: 2.0
+
+shared: &shared
+  steps:
+    - run:
+        name: "Show Node Environment"
+        command: 'echo "node: $(node -v)" && echo "npm:  v$(npm -v)"'
+    - checkout
+    - run: npm install
+    - run: npm run lint
+    - run: npm run prettier
+    - run: npm test
+
+jobs:
+  "node-6":
+    <<: *shared
+    docker:
+      - image: circleci/node:6
+
+  "node-8":
+    <<: *shared
+    docker:
+      - image: circleci/node:8
+
+  "node-10":
+    <<: *shared
+    docker:
+      - image: circleci/node:10
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - "node-6"
+      - "node-8"
+      - "node-10"

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,0 @@
-machine:
-  node:
-    version: 6.12.2

--- a/lib/orderbook.js
+++ b/lib/orderbook.js
@@ -15,21 +15,23 @@ class Orderbook {
 
   state(book) {
     if (book) {
-      book.bids
-        .forEach(order => this.add({
+      book.bids.forEach(order =>
+        this.add({
           id: order[2],
           side: 'buy',
           price: BigNumber(order[0]),
           size: BigNumber(order[1]),
-        }));
+        })
+      );
 
-      book.asks
-        .forEach(order => this.add({
+      book.asks.forEach(order =>
+        this.add({
           id: order[2],
           side: 'sell',
           price: BigNumber(order[0]),
           size: BigNumber(order[1]),
-        }));
+        })
+      );
     } else {
       book = { asks: [], bids: [] };
 

--- a/lib/orderbook_sync.js
+++ b/lib/orderbook_sync.js
@@ -76,9 +76,10 @@ class OrderbookSync extends WebsocketClient {
   // subscriptions changed -- possible new products
   _newSubscription(data) {
     const channel = data.channels.find(c => c.name === 'full');
-    channel && channel.product_ids
-      .filter(productID => !(productID in this.books))
-      .forEach(this._newProduct, this);
+    channel &&
+      channel.product_ids
+        .filter(productID => !(productID in this.books))
+        .forEach(this._newProduct, this);
   }
 
   processMessage(data) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -219,9 +219,9 @@
       }
     },
     "bignumber.js": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-5.0.0.tgz",
-      "integrity": "sha512-KWTu6ZMVk9sxlDJQh2YH1UOnfDP8O8TpxUxgQG/vKASoSnEjK9aVuOueFaPcQEYQ5fyNXNTOYwYw3099RYebWg=="
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-6.0.0.tgz",
+      "integrity": "sha512-x247jIuy60/+FtMRvscqfxtVHQf8AGx2hm9c6btkgC0x/hp9yt+teISNhvF8WlwRkCc5yF2fDECH8SIMe8j+GA=="
     },
     "bintrees": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,9 @@
     "url": "git://github.com/coinbase/gdax-node.git"
   },
   "scripts": {
+    "lint": "eslint --ext .js ./",
+    "prettier": "prettier -l README.md *.js **/*.js",
+    "prettier-write": "npm run prettier -- --write",
     "test": "mocha --full-trace --ui tdd --bail --reporter spec tests/*.js",
     "precommit": "lint-staged"
   },

--- a/package.json
+++ b/package.json
@@ -62,9 +62,6 @@
     "url": "git://github.com/coinbase/gdax-node.git"
   },
   "scripts": {
-    "lint": "eslint --ext .js ./",
-    "prettier": "prettier -l README.md *.js **/*.js",
-    "prettier-write": "npm run prettier -- --write",
     "test": "mocha --full-trace --ui tdd --bail --reporter spec tests/*.js",
     "precommit": "lint-staged"
   },

--- a/tests/authenticated.spec.js
+++ b/tests/authenticated.spec.js
@@ -175,7 +175,7 @@ suite('AuthenticatedClient', () => {
       .then(() => done())
       .catch(err => assert.ifError(err) || assert.fail());
   });
-  
+
   test('.getAccountTransfers()', done => {
     const expectedResponse = [
       {
@@ -741,7 +741,7 @@ suite('AuthenticatedClient', () => {
 
   test('.depositCrypto()', done => {
     const params = {
-      currency: 'BTC'
+      currency: 'BTC',
     };
     const expectedAccountsRespons = [
       {
@@ -751,8 +751,8 @@ suite('AuthenticatedClient', () => {
         currency: 'BTC',
         type: 'wallet',
         primary: true,
-        active: true
-      }
+        active: true,
+      },
     ];
     const expectedAddressResponse = {
       id: 'test-id',
@@ -765,9 +765,10 @@ suite('AuthenticatedClient', () => {
       resource: 'address',
       resource_path: '/v2/accounts/test-account-id/addresses/test-id',
       warning_title: 'Only send Bitcoin (BTC) to this address',
-      warning_details: 'Sending any other digital asset, including Bitcoin Cash (BCH), will result in permanent loss.',
+      warning_details:
+        'Sending any other digital asset, including Bitcoin Cash (BCH), will result in permanent loss.',
       callback_url: null,
-      exchange_deposit_address: true
+      exchange_deposit_address: true,
     };
 
     nock(EXCHANGE_API_URL)

--- a/tests/orderbook_sync.spec.js
+++ b/tests/orderbook_sync.spec.js
@@ -98,13 +98,15 @@ suite('OrderbookSync', () => {
           test: true,
           product_id: 'BTC-USD',
         });
-        server.close();
-        done();
       });
     });
 
     server.on('connection', socket => {
       socket.send(JSON.stringify({ test: true, product_id: 'BTC-USD' }));
+      socket.on('message', () => {
+        server.close();
+        done();
+      });
     });
   });
 
@@ -128,13 +130,15 @@ suite('OrderbookSync', () => {
           test: true,
           product_id: 'BTC-USD',
         });
-        server.close();
-        done();
       });
     });
 
     server.on('connection', socket => {
       socket.send(JSON.stringify({ test: true, product_id: 'BTC-USD' }));
+      socket.on('message', () => {
+        server.close();
+        done();
+      });
     });
   });
 
@@ -152,13 +156,15 @@ suite('OrderbookSync', () => {
 
       orderbookSync.on('error', err => {
         assert.equal(err.message, 'Failed to load orderbook: whoops');
-        server.close();
-        done();
       });
     });
 
     server.on('connection', socket => {
       socket.send(JSON.stringify({ product_id: 'BTC-USD' }));
+      socket.on('message', () => {
+        server.close();
+        done();
+      });
     });
   });
 
@@ -177,13 +183,15 @@ suite('OrderbookSync', () => {
 
       orderbookSync.on('error', err => {
         assert.equal(err.message, 'Failed to load orderbook: whoops');
-        server.close();
-        done();
       });
     });
 
     server.on('connection', socket => {
       socket.send(JSON.stringify({ product_id: 'BTC-USD' }));
+      socket.on('message', () => {
+        server.close();
+        done();
+      });
     });
   });
 
@@ -202,7 +210,6 @@ suite('OrderbookSync', () => {
         bids: [],
       });
 
-    let count = 0;
     const server = testserver(port, () => {
       const orderbookSync = new Gdax.OrderbookSync(
         ['BTC-USD', 'ETH-USD'],
@@ -212,20 +219,18 @@ suite('OrderbookSync', () => {
 
       orderbookSync.on('message', data => {
         const state = orderbookSync.books[data.product_id].state();
-
         assert.deepEqual(state, { asks: [], bids: [] });
         assert.equal(orderbookSync.books['ETH-BTC'], undefined);
-
-        if (++count >= 2) {
-          server.close();
-          done();
-        }
       });
     });
 
     server.on('connection', socket => {
       socket.send(JSON.stringify({ product_id: 'BTC-USD' }));
       socket.send(JSON.stringify({ product_id: 'ETH-USD' }));
+      socket.on('message', () => {
+        server.close();
+        done();
+      });
     });
   });
 
@@ -246,13 +251,15 @@ suite('OrderbookSync', () => {
 
       orderbookSync.on('sync', productID => {
         assert.equal(productID, 'BTC-USD');
-        server.close();
-        done();
       });
     });
 
     server.on('connection', socket => {
       socket.send(JSON.stringify({ product_id: 'BTC-USD' }));
+      socket.on('message', () => {
+        server.close();
+        done();
+      });
     });
   });
 
@@ -273,13 +280,15 @@ suite('OrderbookSync', () => {
 
       orderbookSync.on('synced', productID => {
         assert.equal(productID, 'BTC-USD');
-        server.close();
-        done();
       });
     });
 
     server.on('connection', socket => {
       socket.send(JSON.stringify({ product_id: 'BTC-USD' }));
+      socket.on('message', () => {
+        server.close();
+        done();
+      });
     });
   });
 });

--- a/tests/orderbook_sync.spec.js
+++ b/tests/orderbook_sync.spec.js
@@ -245,9 +245,9 @@ suite('OrderbookSync', () => {
       );
 
       orderbookSync.on('sync', productID => {
-         assert.equal(productID, 'BTC-USD');
-         server.close();
-         done();
+        assert.equal(productID, 'BTC-USD');
+        server.close();
+        done();
       });
     });
 
@@ -272,9 +272,9 @@ suite('OrderbookSync', () => {
       );
 
       orderbookSync.on('synced', productID => {
-         assert.equal(productID, 'BTC-USD');
-         server.close();
-         done();
+        assert.equal(productID, 'BTC-USD');
+        server.close();
+        done();
       });
     });
 

--- a/tests/websocket.spec.js
+++ b/tests/websocket.spec.js
@@ -269,9 +269,6 @@ suite('WebsocketClient', () => {
       client.once('error', err => {
         assert.equal(err.message, 'test error');
         assert.equal(err.reason, 'because error');
-
-        server.close();
-        done();
       });
     });
 
@@ -283,6 +280,10 @@ suite('WebsocketClient', () => {
           reason: 'because error',
         })
       );
+      socket.on('message', () => {
+        server.close();
+        done();
+      });
     });
   });
 });


### PR DESCRIPTION
## What does it do?

- Adds CircleCI build matrix (with node v6, v8, v10)
- Switched to CircleCI version 2
- Also runs a `lint` and `prettier` sanity test prior to running the standard test suite (for people who might disable the `precommit` hooks while using `lint-staged`).

## What else do you need to know?

- Also fixes existing prettier errors
- Also fixes build on Node 6 (timing and `ECONNRESET` issues) on `OrderbookSync` and `WebsocketClient`

- `prettier` is only run against `*.js` files, because different npm versions mess with package.json & package-lock.json differently (causing the build to unnecessarily fail on different versions).

## Related Issues

- Closes #249

## Screenshots

<img width="706" alt="gdax-node 2018-05-14 12-20-53" src="https://user-images.githubusercontent.com/740/40015648-451930dc-5771-11e8-94c9-711b5265ef66.png">

/cc @fb55 
