### PR TITLE
Fixes #196 - add optional order_id param to getFills type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -97,6 +97,7 @@ declare module 'gdax' {
 
     export type FillFilter = {
         product_id?: string;
+        order_id?: string;
     } & PageArgs;
 
     export type OrderFilter = {
@@ -150,9 +151,9 @@ declare module 'gdax' {
         response: HttpResponse;
         data?: any;
     }
-    
+
     export interface ClientOptions {
-        timeout?: number;   
+        timeout?: number;
     }
 
     export class PublicClient {


### PR DESCRIPTION
Updates the `FillFilter` type so `getFills` will not complain when trying to provide an `order_id` parameter. This mirrors the functionality in the API - https://docs.pro.coinbase.com/#list-fills