### PR TITLE
Update getOrders API doc URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ authedClient.cancelOrders(callback);
 authedClient.cancelAllOrders({ product_id: 'BTC-USD' }, callback);
 ```
 
-- [`getOrders`](https://docs.pro.coinbase.com/#list-open-orders)
+- [`getOrders`](https://docs.pro.coinbase.com/#list-orders)
 
 ```js
 authedClient.getOrders(callback);


### PR DESCRIPTION
Updated link from https://docs.pro.coinbase.com/#list-open-orders to https://docs.pro.coinbase.com/#list-orders to match current API Doc