### PR TITLE
Add support for HTTP agent

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,6 @@
 import { EventEmitter } from 'events';
+import http from 'http';
+import https from 'https';
 import * as request from 'request';
 import { Readable } from 'stream';
 
@@ -151,6 +153,7 @@ declare module 'coinbase-pro' {
   }
 
   export interface ClientOptions {
+    agent?: http.Agent | https.Agent;
     timeout?: number;
   }
 

--- a/lib/clients/public.js
+++ b/lib/clients/public.js
@@ -16,6 +16,7 @@ class PublicClient {
 
     this.apiURI = apiURI;
     this.API_LIMIT = 100;
+    this.agent = options.agent;
     this.timeout = +options.timeout > 0 ? options.timeout : DEFAULT_TIMEOUT;
   }
 
@@ -100,6 +101,7 @@ class PublicClient {
     }
 
     Object.assign(opts, {
+      agent: this.agent,
       method: method.toUpperCase(),
       uri: this.makeAbsoluteURI(this.makeRelativeURI(uriParts)),
       qsStringifyOptions: { arrayFormat: 'repeat' },


### PR DESCRIPTION
Add support for HTTP and HTTPS agent for the HTTP client.

Example of usage:
```
import CoinbasePro, { OrderInfo, OrderResult } from 'coinbase-pro';
import HttpsProxyAgent from 'https-proxy-agent';

const coinbaseClient = new CoinbasePro.AuthenticatedClient(
  process.env.COINBASE_API_KEY,
  process.env.COINBASE_API_SECRET,
  process.env.COINBASE_API_PASSPHRASE,
  'https://api.prime.coinbase.com',
  {
    agent: new HttpsProxyAgent(process.env.PROXY_URL),
  },
);
```