### PR TITLE
timestamp needs to be of type string otherwise will get "�invalid (un…

### DIFF
--- a/lib/request_signer.js
+++ b/lib/request_signer.js
@@ -29,7 +29,7 @@ module.exports.signRequest = (auth, method, path, options = {}) => {
   return {
     key: auth.key,
     signature: signature,
-    timestamp: timestamp,
+    timestamp: timestamp.toString(),
     passphrase: auth.passphrase,
   };
 };


### PR DESCRIPTION
As of a couple days ago, if `timestamp` is not of type `string` (was float before), you'd get a subscription message error (see below).  This is only true of coinbase-pro sandbox and not coinbase-pro prod.  Casting to string works for both environments


subscription message error:
```
undefined:1
�invalid (un)subscribe msg
^

SyntaxError: Unexpected token  in JSON at position 0
    at JSON.parse (<anonymous>)
    at WebsocketClient.onMessage (
    at WebSocket.emit (events.js:198:13)
    at WebSocket.EventEmitter.emit (domain.js:448:20)
    at Receiver._receiver.onmessage (
    at Receiver.dataMessage (
    at Receiver.getData (
    at Receiver.startLoop (
    at Receiver.add (
    at TLSSocket.emit (events.js:198:13)
```


to re-produce original error:
```
const websocket = new cbp.WebsocketClient(
      ['BTC-USD'],
      'wss://ws-feed-public.sandbox.pro.coinbase.com,
      {
        key: <enter key>,
        secret: <enter secret>,
        passphrase: <enter passphrase,
      },
      { channels: ['user'] },
    );
```