### PR TITLE
Add support for authenticated fees endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,12 @@ authedClient.getFills({ before: 3000 }, callback);
 authedClient.getFundings({}, callback);
 ```
 
+- [`getFees`](https://docs.pro.coinbase.com/#fees)
+
+```js
+authedClient.getFees(callback);
+```
+
 - [`repay`](https://docs.pro.coinbase.com/#repay)
 
 ```js

--- a/lib/clients/authenticated.js
+++ b/lib/clients/authenticated.js
@@ -224,6 +224,10 @@ class AuthenticatedClient extends PublicClient {
     return this.get(['funding'], callback);
   }
 
+  getFees(callback) {
+    return this.get(['fees'], callback);
+  }
+
   repay(params, callback) {
     this._requireParams(params, ['amount', 'currency']);
     return this.post(['funding/repay'], { body: params }, callback);

--- a/tests/authenticated.spec.js
+++ b/tests/authenticated.spec.js
@@ -617,12 +617,12 @@ suite('AuthenticatedClient', () => {
     };
 
     nock(EXCHANGE_API_URL)
-      .get('/funding')
+      .get('/fees')
       .times(2)
       .reply(200, expectedResponse);
 
     let cbtest = new Promise((resolve, reject) => {
-      authClient.getFundings((err, resp, data) => {
+      authClient.getFees((err, resp, data) => {
         if (err) {
           reject(err);
         }
@@ -631,7 +631,7 @@ suite('AuthenticatedClient', () => {
       });
     });
 
-    let promisetest = authClient.getFundings();
+    let promisetest = authClient.getFees();
 
     Promise.all([cbtest, promisetest])
       .then(() => done())

--- a/tests/authenticated.spec.js
+++ b/tests/authenticated.spec.js
@@ -609,6 +609,35 @@ suite('AuthenticatedClient', () => {
       .catch(err => assert.ifError(err) || assert.fail());
   });
 
+  test('.getFees()', done => {
+    const expectedResponse = {
+      maker_fee_rate: '0.0050',
+      taker_fee_rate: '0.0050',
+      usd_volume: '500.00',
+    };
+
+    nock(EXCHANGE_API_URL)
+      .get('/funding')
+      .times(2)
+      .reply(200, expectedResponse);
+
+    let cbtest = new Promise((resolve, reject) => {
+      authClient.getFundings((err, resp, data) => {
+        if (err) {
+          reject(err);
+        }
+        assert.deepEqual(data, expectedResponse);
+        resolve();
+      });
+    });
+
+    let promisetest = authClient.getFundings();
+
+    Promise.all([cbtest, promisetest])
+      .then(() => done())
+      .catch(err => assert.ifError(err) || assert.fail());
+  });
+
   test('.repay()', done => {
     const params = {
       amount: 10000,


### PR DESCRIPTION
I wanted to spam this endpoint, and noticed it wasnt supported on this library, only took a few minutes to do with this super clean lib to copypasta from.